### PR TITLE
docs: add contribution guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,51 @@ Phase 3（可视化层）
 
 ---
 
+## 贡献指南
+
+**所有参与者必须遵守完整的 Issue/PR 流程。**
+
+### 流程规范
+
+```
+1. 创建 Issue（描述要完整，包含验收标准）
+2. 创建分支：git checkout -b feat/{issue-id}-{short-description}
+3. 开发 + 测试
+4. 提交 PR（包含：解决什么问题、怎么验证）
+5. Code Review（至少 1 人 Approve）
+6. Merge to master
+```
+
+### 分支命名
+
+| 类型 | 格式 | 示例 |
+|------|------|------|
+| 功能 | `feat/{issue-id}-{description}` | `feat/2-TDD-phase1` |
+| 修复 | `fix/{issue-id}-{description}` | `fix/42-vault-path-bug` |
+| 文档 | `docs/{issue-id}-{description}` | `docs/5-contribution-guide` |
+
+### PR 规范
+
+- **Title**: `{type}: {简短描述}` （如 `feat: implement scoring engine decay`）
+- **Description** 必须包含：
+  - 解决了什么问题
+  - 怎么验证（测试说明 / 截图）
+  - 影响范围
+- **最小 PR 原则**：一个 PR 只解决一个问题
+- **Review 通过前禁止 self-merge**
+
+### Code Review 要求
+
+- 审核者需明确 Approve 或 Request Changes
+- 结构性变更（架构、数据库 Schema）必须 CTO Review
+- 文档更新同样需要 Review（不允许 self-merge）
+
+### ⚠️ 重要
+
+> **此要求适用于所有变更类型——代码、文档、配置、CI/CD。本规则本身更新也必须走 Issue/PR 流程。**
+
+---
+
 ## License
 
 **Compass Open License (COL)**


### PR DESCRIPTION
## Summary

在 README.md 中增加贡献指南，明确所有参与者必须遵守完整的 Issue/PR 流程。

## Changes

- 新增「贡献指南」章节
- 分支命名规范（feat/fix/docs）
- PR 规范（title、description、review 要求）
- Code Review 要求（CTO 审核架构变更）
- self-merge 禁止
- 强调此要求适用于所有变更类型（代码/文档/配置/CI）
- **本规则本身更新也必须走 Issue/PR 流程**

## Verification

- [ ] README.md 包含完整贡献流程
- [ ] 流程说明清晰，可操作
- [ ] 强调所有变更类型均需遵循

Closes #5