### PR TITLE
feat: compass-core skeleton - Week 1 骨架

### DIFF
--- a/compass-core/.gitignore
+++ b/compass-core/.gitignore
@@ -1,0 +1,2 @@
+/target/
+Cargo.lock

--- a/compass-core/Cargo.toml
+++ b/compass-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "compass_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+regex = "1.10"
+chrono = { version = "0.4", features = ["serde"] }
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = "3"

--- a/compass-core/Cargo.toml
+++ b/compass-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.10"
+once_cell = "1.19"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
 env_logger = "0.11"

--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -1,0 +1,32 @@
+//! compass-core — Rust binary for Compass scoring engine and reference parsing.
+//!
+//! Usage (subprocess mode):
+//!   echo '{"jsonrpc":"2.0","method":"compute_score","params":{...},"id":1}' | compass_core
+//!
+//! Modes:
+//!   (no args) — RPC mode over stdin/stdout (default)
+//!   --test     — Run unit tests
+
+mod models;
+mod reference;
+mod rpc;
+mod scoring;
+
+use std::env;
+
+fn main() {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() > 1 && args[1] == "--test" {
+        // Run tests and exit
+        // Note: in real usage, `cargo test` handles this
+        // This flag is for the Python test runner to verify the binary
+        println!("Binary OK — RPC mode ready");
+        return;
+    }
+
+    // Default: RPC server mode
+    rpc::run();
+}

--- a/compass-core/src/models.rs
+++ b/compass-core/src/models.rs
@@ -1,0 +1,56 @@
+//! Shared data structures for Rust-Python communication via JSON-RPC.
+//!
+//! All structures are serialized to/from JSON for subprocess communication.
+
+use serde::{Deserialize, Serialize};
+
+/// Input for scoring computation.
+/// Passed via JSON-RPC `params` field.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ScoringInput {
+    pub interest: f64,
+    pub strategy: f64,
+    pub consensus: f64,
+    /// ISO 8601 timestamp of last boost event.
+    pub last_boosted_at: String,
+    /// Half-life in days for interest decay. Default: 30.0
+    #[serde(default = "default_interest_half_life")]
+    pub interest_half_life_days: f64,
+    /// Half-life in days for strategy decay. Default: 365.0
+    #[serde(default = "default_strategy_half_life")]
+    pub strategy_half_life_days: f64,
+    /// Half-life in days for consensus decay. Default: 60.0
+    #[serde(default = "default_consensus_half_life")]
+    pub consensus_half_life_days: f64,
+}
+
+fn default_interest_half_life() -> f64 { 30.0 }
+fn default_strategy_half_life() -> f64 { 365.0 }
+fn default_consensus_half_life() -> f64 { 60.0 }
+
+/// Output from scoring computation.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ScoringOutput {
+    pub final_score: f64,
+    pub decay_factor: f64,
+    pub days_elapsed: f64,
+}
+
+/// Input for reference parsing.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ReferenceInput {
+    /// Raw markdown content to extract [[id]] references from.
+    pub content: String,
+    /// Optional: filter out self-references to this entity ID.
+    pub current_entity_id: Option<String>,
+}
+
+/// Output from reference parsing.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ReferenceOutput {
+    pub refs: Vec<String>,
+}

--- a/compass-core/src/reference.rs
+++ b/compass-core/src/reference.rs
@@ -1,0 +1,77 @@
+//! Reference parser — extracts [[id]] bidirectional links from markdown content.
+
+use crate::models::{ReferenceInput, ReferenceOutput};
+use regex::Regex;
+
+/// Parser for [[id]] style references in markdown.
+pub struct ReferenceParser;
+
+impl ReferenceParser {
+    /// Extract all unique [[id]] references from content.
+    /// If `current_entity_id` is provided, filters out self-references.
+    pub fn extract_ids(content: &str, current_entity_id: Option<&str>) -> Vec<String> {
+        let re = Regex::new(r#"\[\[([a-zA-Z0-9_-]+)\]\]"#).unwrap();
+
+        let mut ids: Vec<String> = re
+            .captures_iter(content)
+            .map(|cap| cap.get(1).unwrap().as_str().to_string())
+            .collect();
+
+        // Deduplicate
+        ids.sort();
+        ids.dedup();
+
+        // Filter self-reference if specified
+        if let Some(self_id) = current_entity_id {
+            ids.retain(|id| id != self_id);
+        }
+
+        ids
+    }
+
+    /// Parse input and return output struct.
+    pub fn parse(input: ReferenceInput) -> ReferenceOutput {
+        let refs = Self::extract_ids(&input.content, input.current_entity_id.as_deref());
+        ReferenceOutput { refs }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reference_extraction() {
+        let content = "这是 [[entity-001]] 和 [[entity-002]] 的核心观点";
+        let refs = ReferenceParser::extract_ids(content, None);
+        assert_eq!(refs, vec!["entity-001", "entity-002"]);
+    }
+
+    #[test]
+    fn test_self_reference_filtered() {
+        let content = "关于 [[entity-001]] 的讨论";
+        let refs = ReferenceParser::extract_ids(content, Some("entity-001"));
+        assert!(!refs.contains(&"entity-001".to_string()));
+    }
+
+    #[test]
+    fn test_duplicate_refs_deduplicated() {
+        let content = "[[id1]] 和 [[id1]] 和 [[id2]]";
+        let refs = ReferenceParser::extract_ids(content, None);
+        assert_eq!(refs, vec!["id1", "id2"]);
+    }
+
+    #[test]
+    fn test_no_refs() {
+        let content = "这是一段没有引用的普通文本";
+        let refs = ReferenceParser::extract_ids(content, None);
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_complex_id_with_underscore() {
+        let content = "参考 [[comp_v2-2026_04-01]] 这个实体";
+        let refs = ReferenceParser::extract_ids(content, None);
+        assert_eq!(refs, vec!["comp_v2-2026_04-01"]);
+    }
+}

--- a/compass-core/src/reference.rs
+++ b/compass-core/src/reference.rs
@@ -1,7 +1,12 @@
 //! Reference parser — extracts [[id]] bidirectional links from markdown content.
 
 use crate::models::{ReferenceInput, ReferenceOutput};
+use once_cell::sync::Lazy;
 use regex::Regex;
+
+static REF_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"\[\[([a-zA-Z0-9_-]+)\]\]"#).unwrap()
+});
 
 /// Parser for [[id]] style references in markdown.
 pub struct ReferenceParser;
@@ -10,7 +15,7 @@ impl ReferenceParser {
     /// Extract all unique [[id]] references from content.
     /// If `current_entity_id` is provided, filters out self-references.
     pub fn extract_ids(content: &str, current_entity_id: Option<&str>) -> Vec<String> {
-        let re = Regex::new(r#"\[\[([a-zA-Z0-9_-]+)\]\]"#).unwrap();
+        let re = &*REF_RE;
 
         let mut ids: Vec<String> = re
             .captures_iter(content)

--- a/compass-core/src/rpc.rs
+++ b/compass-core/src/rpc.rs
@@ -1,0 +1,109 @@
+//! JSON-RPC server over stdin/stdout.
+//!
+//! Handles two methods:
+//! - `compute_score` — delegates to ScoringEngine
+//! - `parse_refs` — delegates to ReferenceParser
+
+use crate::models::{ReferenceInput, ScoringInput};
+use crate::scoring::ScoringEngine;
+use crate::reference::ReferenceParser;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+struct RpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    method: String,
+    params: Value,
+    id: Value,
+}
+
+const JSONRPC_VERSION: &str = "2.0";
+
+/// Read JSON-RPC request from stdin, write response to stdout.
+pub fn run() {
+    // Read entire stdin
+    let mut input = String::new();
+    std::io::Read::read_to_string(&mut std::io::stdin(), &mut input).unwrap();
+
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    // Parse the outer envelope to get method and id
+    let envelope: RpcRequest = match serde_json::from_str(trimmed) {
+        Ok(req) => req,
+        Err(e) => {
+            let id = serde_json::from_str::<Value>(trimmed)
+                .ok()
+                .and_then(|v| v.get("id").cloned())
+                .unwrap_or(serde_json::Value::Null);
+            let err = serde_json::json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "error": {
+                    "code": -32700,
+                    "message": format!("Parse error: {}", e)
+                },
+                "id": id
+            });
+            println!("{}", err);
+            return;
+        }
+    };
+
+    // Dispatch by method name
+    let response: Value = match envelope.method.as_str() {
+        "compute_score" => {
+            match serde_json::from_value::<ScoringInput>(envelope.params) {
+                Ok(p) => {
+                    let output = ScoringEngine::compute(p);
+                    serde_json::json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "result": output,
+                        "id": envelope.id
+                    })
+                }
+                Err(msg) => {
+                    serde_json::json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "error": { "code": -32602, "message": msg.to_string() },
+                        "id": envelope.id
+                    })
+                }
+            }
+        }
+        "parse_refs" => {
+            match serde_json::from_value::<ReferenceInput>(envelope.params) {
+                Ok(p) => {
+                    let output = ReferenceParser::parse(p);
+                    serde_json::json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "result": output,
+                        "id": envelope.id
+                    })
+                }
+                Err(msg) => {
+                    serde_json::json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "error": { "code": -32602, "message": msg.to_string() },
+                        "id": envelope.id
+                    })
+                }
+            }
+        }
+        _ => {
+            serde_json::json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "error": {
+                    "code": -32601,
+                    "message": format!("Method not found: {}", envelope.method)
+                },
+                "id": envelope.id
+            })
+        }
+    };
+
+    println!("{}", response);
+}

--- a/compass-core/src/rpc.rs
+++ b/compass-core/src/rpc.rs
@@ -4,6 +4,8 @@
 //! - `compute_score` — delegates to ScoringEngine
 //! - `parse_refs` — delegates to ReferenceParser
 
+use std::io::Read;
+
 use crate::models::{ReferenceInput, ScoringInput};
 use crate::scoring::ScoringEngine;
 use crate::reference::ReferenceParser;
@@ -25,10 +27,20 @@ const JSONRPC_VERSION: &str = "2.0";
 pub fn run() {
     // Read entire stdin
     let mut input = String::new();
-    std::io::Read::read_to_string(&mut std::io::stdin(), &mut input).unwrap();
+    if std::io::stdin().read_to_string(&mut input).is_err() {
+        // Return parse error JSON instead of panicking
+        let err = serde_json::json!({
+            "jsonrpc": "2.0",
+            "error": { "code": -32700, "message": "Failed to read stdin" },
+            "id": serde_json::Value::Null
+        });
+        println!("{}", err);
+        return;
+    }
 
     let trimmed = input.trim();
     if trimmed.is_empty() {
+        // Empty input — silent exit (e.g., pipe with no data)
         return;
     }
 

--- a/compass-core/src/scoring.rs
+++ b/compass-core/src/scoring.rs
@@ -40,39 +40,32 @@ pub struct ScoringEngine;
 
 impl ScoringEngine {
     /// Compute final score with decay applied to each dimension.
+    /// Method 2: each dimension independently decays, then weighted sum.
+    /// final = (interest * decay_i * 0.4) + (strategy * decay_s * 0.35) + (consensus * decay_c * 0.25)
     pub fn compute(input: ScoringInput) -> ScoringOutput {
-        let (days_elapsed, decay_factor) =
-            Self::compute_decay_factor(&input.last_boosted_at);
-
-        // Weighted base score (pre-decay)
-        let base_score =
-            input.interest * WEIGHT_INTEREST
-            + input.strategy * WEIGHT_STRATEGY
-            + input.consensus * WEIGHT_CONSENSUS;
-
-        let final_score = base_score * decay_factor;
-
-        ScoringOutput {
-            final_score: Self::round2(final_score),
-            decay_factor: Self::round6(decay_factor),
-            days_elapsed: Self::round2(days_elapsed),
-        }
-    }
-
-    /// Compute the composite decay factor from all three half-lives.
-    fn compute_decay_factor(last_boosted_at: &str) -> (f64, f64) {
-        let days_elapsed = Self::days_since(last_boosted_at);
+        let days_elapsed = Self::days_since(&input.last_boosted_at);
 
         let decay_interest = DecayCalculator::new(30.0).factor(days_elapsed);
         let decay_strategy = DecayCalculator::new(365.0).factor(days_elapsed);
         let decay_consensus = DecayCalculator::new(60.0).factor(days_elapsed);
 
-        // Composite decay = weighted average of individual decays
-        let composite = decay_interest * WEIGHT_INTEREST
+        // Each dimension independently decayed, then weighted
+        let final_score =
+            input.interest * decay_interest * WEIGHT_INTEREST
+            + input.strategy * decay_strategy * WEIGHT_STRATEGY
+            + input.consensus * decay_consensus * WEIGHT_CONSENSUS;
+
+        // Composite decay factor for reporting
+        let decay_factor =
+            decay_interest * WEIGHT_INTEREST
             + decay_strategy * WEIGHT_STRATEGY
             + decay_consensus * WEIGHT_CONSENSUS;
 
-        (days_elapsed, composite)
+        ScoringOutput {
+            final_score: Self::round2(final_score),
+            decay_factor: Self::round2(decay_factor),
+            days_elapsed: Self::round2(days_elapsed),
+        }
     }
 
     /// Parse ISO 8601 timestamp and compute days since.
@@ -90,11 +83,7 @@ impl ScoringEngine {
     }
 
     fn round2(v: f64) -> f64 {
-        (v * 100.0).round() / 100.0
-    }
-
-    fn round6(v: f64) -> f64 {
-        (v * 1_000_000.0).round() / 1_000_000.0
+        format!("{:.2}", v).parse().unwrap_or(v)
     }
 }
 

--- a/compass-core/src/scoring.rs
+++ b/compass-core/src/scoring.rs
@@ -1,0 +1,154 @@
+//! Scoring engine with decay calculation.
+//!
+//! # Weights
+//! - interest: 0.40
+//! - strategy: 0.35
+//! - consensus: 0.25
+//!
+//! # Decay Formula
+//! `decay_factor = 0.5 ^ (days_elapsed / half_life_days)`
+
+use crate::models::{ScoringInput, ScoringOutput};
+
+const WEIGHT_INTEREST: f64 = 0.40;
+const WEIGHT_STRATEGY: f64 = 0.35;
+const WEIGHT_CONSENSUS: f64 = 0.25;
+
+/// Decay calculator using exponential half-life model.
+#[derive(Debug, Clone)]
+pub struct DecayCalculator {
+    half_life_days: f64,
+}
+
+impl DecayCalculator {
+    pub fn new(half_life_days: f64) -> Self {
+        Self { half_life_days }
+    }
+
+    /// Compute decay factor for a given number of days elapsed.
+    /// Returns `0.5 ^ (days / half_life)`.
+    pub fn factor(&self, days_elapsed: f64) -> f64 {
+        if self.half_life_days <= 0.0 {
+            return 1.0;
+        }
+        0.5_f64.powf(days_elapsed / self.half_life_days)
+    }
+}
+
+/// Scoring engine — computes final scores with multi-dimension decay.
+pub struct ScoringEngine;
+
+impl ScoringEngine {
+    /// Compute final score with decay applied to each dimension.
+    pub fn compute(input: ScoringInput) -> ScoringOutput {
+        let (days_elapsed, decay_factor) =
+            Self::compute_decay_factor(&input.last_boosted_at);
+
+        // Weighted base score (pre-decay)
+        let base_score =
+            input.interest * WEIGHT_INTEREST
+            + input.strategy * WEIGHT_STRATEGY
+            + input.consensus * WEIGHT_CONSENSUS;
+
+        let final_score = base_score * decay_factor;
+
+        ScoringOutput {
+            final_score: Self::round2(final_score),
+            decay_factor: Self::round6(decay_factor),
+            days_elapsed: Self::round2(days_elapsed),
+        }
+    }
+
+    /// Compute the composite decay factor from all three half-lives.
+    fn compute_decay_factor(last_boosted_at: &str) -> (f64, f64) {
+        let days_elapsed = Self::days_since(last_boosted_at);
+
+        let decay_interest = DecayCalculator::new(30.0).factor(days_elapsed);
+        let decay_strategy = DecayCalculator::new(365.0).factor(days_elapsed);
+        let decay_consensus = DecayCalculator::new(60.0).factor(days_elapsed);
+
+        // Composite decay = weighted average of individual decays
+        let composite = decay_interest * WEIGHT_INTEREST
+            + decay_strategy * WEIGHT_STRATEGY
+            + decay_consensus * WEIGHT_CONSENSUS;
+
+        (days_elapsed, composite)
+    }
+
+    /// Parse ISO 8601 timestamp and compute days since.
+    fn days_since(timestamp: &str) -> f64 {
+
+        let Ok(dt) = chrono::DateTime::parse_from_rfc3339(timestamp) else {
+            log::warn!("Failed to parse timestamp '{}', assuming 0 days", timestamp);
+            return 0.0;
+        };
+        let dt = dt.with_timezone(&chrono::Utc);
+
+        let now = chrono::Utc::now();
+        let duration = now.signed_duration_since(dt);
+        duration.num_seconds() as f64 / (24.0 * 3600.0)
+    }
+
+    fn round2(v: f64) -> f64 {
+        (v * 100.0).round() / 100.0
+    }
+
+    fn round6(v: f64) -> f64 {
+        (v * 1_000_000.0).round() / 1_000_000.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decay_half_life_exact() {
+        let decay = DecayCalculator::new(30.0);
+        let factor = decay.factor(30.0);
+        assert!((factor - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_decay_quarter_life() {
+        // 15 days ≈ sqrt(0.5) ≈ 0.707
+        let decay = DecayCalculator::new(30.0);
+        let factor = decay.factor(15.0);
+        assert!((factor - 0.7071).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_final_score_zero_days() {
+        let now = chrono::Utc::now().to_rfc3339();
+        let input = ScoringInput {
+            interest: 10.0,
+            strategy: 10.0,
+            consensus: 10.0,
+            last_boosted_at: now,
+            interest_half_life_days: 30.0,
+            strategy_half_life_days: 365.0,
+            consensus_half_life_days: 60.0,
+        };
+        let output = ScoringEngine::compute(input);
+        // All weights sum to 1.0, decay_factor = 1.0 at 0 days
+        assert!((output.final_score - 10.0).abs() < 0.01);
+        assert!((output.decay_factor - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_final_score_formula_weights() {
+        let now = chrono::Utc::now().to_rfc3339();
+        let input = ScoringInput {
+            interest: 8.0,
+            strategy: 9.0,
+            consensus: 4.0,
+            last_boosted_at: now,
+            interest_half_life_days: 30.0,
+            strategy_half_life_days: 365.0,
+            consensus_half_life_days: 60.0,
+        };
+        let output = ScoringEngine::compute(input);
+        // 8*0.4 + 9*0.35 + 4*0.25 = 3.2 + 3.15 + 1.0 = 7.35
+        assert!((output.final_score - 7.35).abs() < 0.01);
+    }
+}


### PR DESCRIPTION
## 变更摘要

compass-core Rust 项目骨架，包含 Week 1 必须交付的四个组件。

### 模块

| 文件 | 功能 |
|------|------|
| `src/models.rs` | ScoringInput/Output, ReferenceInput/Output 数据结构 |
| `src/scoring.rs` | ScoringEngine + DecayCalculator，权重 interest 0.4 / strategy 0.35 / consensus 0.25 |
| `src/reference.rs` | ReferenceParser，`[[id]]` 正则提取 |
| `src/rpc.rs` | JSON-RPC subprocess server（stdin/stdout）|
| `src/main.rs` | CLI 入口，RPC 模式默认启动 |

### 验证结果

- `cargo test` ✅ 9 tests passed
- JSON-RPC 协议验证：
  - `compute_score` → `final_score: 7.32`
  - `parse_refs` → `refs: ["entity-001","entity-002"]`

---

## Review 修复 (fa559cc)

| 问题 | 修复方式 |
|------|---------|
| Regex 重复编译 | `once_cell::Lazy<Regex>` static 缓存 |
| stdin panic | 读取失败返回 JSON 错误码 -32700 |
| Decay 公式 | **改用方法二**：各维度独立衰减后再加权（jadelaglace 确认） |
| 浮点精度 | `format!("{:.2}", v).parse()` |

**Decay 公式（方法二）：**
```
final = (interest × decay_i × 0.4) + (strategy × decay_s × 0.35) + (consensus × decay_c × 0.25)
```