### PR TITLE
feat: FileWatcher + PUT/DELETE entity endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ __pycache__/
 .env.*
 *.pem
 *.key
+bin/
+data/
+.venv/
+*.db
+*.db-shm
+*.db-wal
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@ data/
 *.db
 *.db-shm
 *.db-wal
+vault/
+
 .env

--- a/compass-api/pyproject.toml
+++ b/compass-api/pyproject.toml
@@ -10,9 +10,14 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "httpx>=0.28.0",
     "watchdog>=4.0.0",
+    "python-frontmatter>=1.1.0",
     "python-dotenv>=1.0.0",
     "lark-oapi>=1.5.0,<1.6.0",
 ]
+
+[project.scripts]
+compass-api  = "src.main:run"
+compass-watch = "src.services.filewatcher:run_watcher"
 
 [project.optional-dependencies]
 dev = [

--- a/compass-api/pyproject.toml
+++ b/compass-api/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "compass_api"
+version = "0.1.0"
+description = "Compass API — Python glue layer for compass-core"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    "pydantic>=2.10.0",
+    "aiosqlite>=0.20.0",
+    "httpx>=0.28.0",
+    "watchdog>=4.0.0",
+    "python-dotenv>=1.0.0",
+    "lark-oapi>=1.5.0,<1.6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.25.0",
+    "pytest-cov>=6.0.0",
+    "black>=25.0.0",
+    "ruff>=0.9.0",
+    "mypy>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = ["src/"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/"]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+target-version = "py311"
+select = ["ALL"]
+ignore = ["ANN101", "ANN102", "COM812", "ISC001"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true

--- a/compass-api/src/__init__.py
+++ b/compass-api/src/__init__.py
@@ -1,0 +1,1 @@
+# Compass API

--- a/compass-api/src/api/__init__.py
+++ b/compass-api/src/api/__init__.py
@@ -1,0 +1,1 @@
+# API routes

--- a/compass-api/src/api/agent.py
+++ b/compass-api/src/api/agent.py
@@ -1,0 +1,48 @@
+"""Agent-facing endpoints — context injection and tool interfaces."""
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from src.db.database import Database, get_db
+from src.core.rust_client import rust_client
+
+router = APIRouter(prefix="/agent", tags=["agent"])
+
+
+class ContextRequest(BaseModel):
+    task: str
+    top_k: int = 5
+
+
+class ContextResponse(BaseModel):
+    context: list[dict]
+    suggested_entities: list[str]
+    reasoning: str
+
+
+@router.post("/context", response_model=ContextResponse)
+async def get_context(req: ContextRequest, db: Database = Depends(get_db)) -> ContextResponse:
+    candidates = await db.search_entities(req.task, limit=req.top_k * 2)
+    if not candidates:
+        return ContextResponse(context=[], suggested_entities=[], reasoning="No entities found for query.")
+
+    scored = []
+    for e in candidates:
+        last_boosted = e.get("last_boosted_at", "")
+        score_result = rust_client.compute_score(
+            interest=float(e.get("interest", 5.0)),
+            strategy=float(e.get("strategy", 5.0)),
+            consensus=float(e.get("consensus", 0.0)),
+            last_boosted_at=last_boosted,
+        )
+        e["final_score"] = round(score_result.final_score, 2)
+        scored.append(e)
+
+    scored.sort(key=lambda x: x["final_score"], reverse=True)
+    top = scored[: req.top_k]
+    suggested = [s["id"] for s in scored[req.top_k : req.top_k * 2]]
+
+    return ContextResponse(
+        context=top,
+        suggested_entities=suggested,
+        reasoning=f"Selected top {len(top)} by weighted score (strategy×0.35 + interest×0.4 + consensus×0.25) × decay.",
+    )

--- a/compass-api/src/api/agent.py
+++ b/compass-api/src/api/agent.py
@@ -27,11 +27,11 @@ async def get_context(req: ContextRequest, db: Database = Depends(get_db)) -> Co
 
     scored = []
     for e in candidates:
-        last_boosted = e.get("last_boosted_at", "")
+        last_boosted = e.get("last_boosted_at") or ""
         score_result = rust_client.compute_score(
-            interest=float(e.get("interest", 5.0)),
-            strategy=float(e.get("strategy", 5.0)),
-            consensus=float(e.get("consensus", 0.0)),
+            interest=float(e.get("interest") or 5.0),
+            strategy=float(e.get("strategy") or 5.0),
+            consensus=float(e.get("consensus") or 0.0),
             last_boosted_at=last_boosted,
         )
         e["final_score"] = round(score_result.final_score, 2)

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -9,7 +9,73 @@ from src import config
 from src.db.database import Database, get_db
 from src.core.rust_client import rust_client
 
+# ---- entity ID normalization (mirrors FileWatcher's vault_path_to_entity_id) ----
+
+import re
+
+_STRIP_EXT_RE = re.compile(r"\.(md|MD|markdown|MARKDOWN)$")
+_MULTI_DASH_RE = re.compile(r"-+")
+
+
+def normalize_entity_id(raw: str) -> str:
+    """Normalize a raw wiki-link or vault-path to a canonical entity ID.
+
+    Mirrors FileWatcher's vault_path_to_entity_id so that Rust-extracted
+    refs and the current_entity_id are on the same baseline for self-filtering.
+    """
+    # Strip file extension
+    stem = _STRIP_EXT_RE.sub("", raw)
+    # Replace path separators with dash
+    stem = stem.replace("/", "-").replace("\\", "-")
+    # Collapse multiple dashes
+    stem = _MULTI_DASH_RE.sub("-", stem)
+    # Strip leading/trailing dashes
+    return stem.strip("-").lower()
+
+
 router = APIRouter(prefix="/entities", tags=["entities"])
+
+
+# Reusable score computation shared by create and update.
+def _compute_score_and_refs(
+    interest: float,
+    strategy: float,
+    consensus: float,
+    content: Optional[str],
+    entity_id: str,
+) -> tuple[dict, list[str]]:
+    """Compute score via Rust and extract refs if content is provided.
+
+    Returns (score_data, ref_ids).
+    """
+    now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    refs: list[str] = []
+    if content:
+        refs_result = rust_client.parse_refs(content, current_id=entity_id)
+        raw_refs = refs_result.refs
+        # Normalize refs so self-reference filtering works correctly:
+        # Rust extracts e.g. "Projects/compass-v2"; entity_id is "projects-compass-v2"
+        normalized_entity_id = normalize_entity_id(entity_id)
+        refs = [
+            r for r in (normalize_entity_id(r) for r in raw_refs)
+            if r != normalized_entity_id
+        ]
+
+    score_result = rust_client.compute_score(
+        interest=interest,
+        strategy=strategy,
+        consensus=consensus,
+        last_boosted_at=now,
+    )
+    score_data = {
+        "entity_id": entity_id,
+        "interest": interest,
+        "strategy": strategy,
+        "consensus": consensus,
+        "final_score": round(score_result.final_score, 2),
+        "updated_at": now,
+    }
+    return score_data, refs
 
 
 class EntityCreate(BaseModel):
@@ -41,18 +107,8 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
     vault_path = entity.vault_path
     file_path = entity.file_path or str(config.VAULT_PATH / vault_path)
 
-    # Parse refs via Rust (outside transaction — read-only)
-    refs: list[str] = []
-    if entity.content:
-        refs_result = rust_client.parse_refs(entity.content, current_id=entity.id)
-        refs = refs_result.refs
-
-    # Score via Rust (outside transaction — read-only computation)
-    score_result = rust_client.compute_score(
-        interest=entity.interest,
-        strategy=entity.strategy,
-        consensus=entity.consensus,
-        last_boosted_at=now,
+    score_data, refs = _compute_score_and_refs(
+        entity.interest, entity.strategy, entity.consensus, entity.content, entity.id
     )
 
     entity_data = {
@@ -64,15 +120,6 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
         "created_at": now,
         "updated_at": now,
         "metadata": entity.metadata,
-    }
-
-    score_data = {
-        "entity_id": entity.id,
-        "interest": entity.interest,
-        "strategy": entity.strategy,
-        "consensus": entity.consensus,
-        "final_score": round(score_result.final_score, 2),
-        "updated_at": now,
     }
 
     # Atomic write: entity + score + refs + event all succeed or all rollback
@@ -89,7 +136,7 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
         title=entity.title,
         category=entity.category,
         vault_path=vault_path,
-        final_score=round(score_result.final_score, 2),
+        final_score=score_data["final_score"],
         created_at=now,
         updated_at=now,
     )
@@ -107,6 +154,96 @@ async def top_entities(
 ) -> dict:
     results = await db.get_top_entities(limit=limit, category=category)
     return {"results": results, "count": len(results)}
+
+
+@router.put("/{entity_id}", response_model=EntityResponse)
+async def update_entity(
+    entity_id: str,
+    update: EntityCreate,
+    db: Database = Depends(get_db)
+) -> EntityResponse:
+    """Full update: re-parses content for refs, recomputes scores.
+
+    Used by FileWatcher when a vault file changes.
+    """
+    existing = await db.get_entity(entity_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    # Guard: body id must match URL path id
+    if update.id != entity_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"ID mismatch: body has '{update.id}', URL has '{entity_id}'",
+        )
+
+    now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    vault_path = update.vault_path
+    file_path = update.file_path or str(config.VAULT_PATH / vault_path)
+
+    score_data, refs = _compute_score_and_refs(
+        update.interest, update.strategy, update.consensus, update.content, entity_id
+    )
+
+    entity_data = {
+        "id": entity_id,
+        "file_path": file_path,
+        "vault_path": vault_path,
+        "title": update.title,
+        "category": update.category,
+        "created_at": existing["created_at"],  # preserve original
+        "updated_at": now,
+        "metadata": update.metadata,
+    }
+
+    # Atomic: upsert entity + score + replace refs + event
+    await db.begin()
+    try:
+        await db.upsert_entity(entity_data)
+        await db.upsert_score(score_data)
+        # Replace outgoing refs: delete all then re-insert
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ?', (entity_id,))
+        for ref_id in refs:
+            await db.upsert_reference(entity_id, ref_id)
+        await db.log_event(entity_id, "updated", trigger="filewatcher")
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return EntityResponse(
+        id=entity_id,
+        title=update.title,
+        category=update.category,
+        vault_path=vault_path,
+        final_score=score_data["final_score"],
+        created_at=entity_data["created_at"],
+        updated_at=now,
+    )
+
+
+@router.delete("/{entity_id}")
+async def delete_entity(entity_id: str, db: Database = Depends(get_db)) -> dict:
+    """Delete entity and all associated data (scores, refs, events).
+
+    Used by FileWatcher when a vault file is removed.
+    """
+    existing = await db.get_entity(entity_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    await db.begin()
+    try:
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ? OR target_id = ?', (entity_id, entity_id))
+        await db.conn.execute("DELETE FROM timeline_events WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM scores WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM entities WHERE id = ?", (entity_id,))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return {"deleted": entity_id}
 
 
 @router.get("/{entity_id}")

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -1,0 +1,117 @@
+"""REST endpoints for entity management."""
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+
+from src import config
+from src.db.database import Database, get_db
+from src.core.rust_client import rust_client
+
+router = APIRouter(prefix="/entities", tags=["entities"])
+
+
+class EntityCreate(BaseModel):
+    id: str
+    title: str
+    category: str = "Inbox"
+    vault_path: str = Field(description="Path inside vault, e.g. Inbox/note.md")
+    file_path: Optional[str] = None
+    interest: float = 5.0
+    strategy: float = 5.0
+    consensus: float = 0.0
+    content: Optional[str] = None  # Markdown body — used for ref extraction
+    metadata: dict = Field(default_factory=dict)
+
+
+class EntityResponse(BaseModel):
+    id: str
+    title: str
+    category: str
+    vault_path: str
+    final_score: float
+    created_at: str
+    updated_at: str
+
+
+@router.post("", response_model=EntityResponse)
+async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) -> EntityResponse:
+    now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    vault_path = entity.vault_path
+    file_path = entity.file_path or str(config.VAULT_PATH / vault_path)
+
+    # Parse refs via Rust
+    refs: list[str] = []
+    if entity.content:
+        refs_result = rust_client.parse_refs(entity.content, current_id=entity.id)
+        refs = refs_result.refs
+
+    # Score via Rust
+    score_result = rust_client.compute_score(
+        interest=entity.interest,
+        strategy=entity.strategy,
+        consensus=entity.consensus,
+        last_boosted_at=now,
+    )
+
+    # Persist entity
+    await db.upsert_entity({
+        "id": entity.id,
+        "file_path": file_path,
+        "vault_path": vault_path,
+        "title": entity.title,
+        "category": entity.category,
+        "created_at": now,
+        "updated_at": now,
+        "metadata": entity.metadata,
+    })
+
+    # Persist score
+    await db.upsert_score({
+        "entity_id": entity.id,
+        "interest": entity.interest,
+        "strategy": entity.strategy,
+        "consensus": entity.consensus,
+        "final_score": round(score_result.final_score, 2),
+        "updated_at": now,
+    })
+
+    # Persist references
+    for ref_id in refs:
+        await db.upsert_reference(entity.id, ref_id)
+
+    await db.log_event(entity.id, "created", trigger="api")
+
+    return EntityResponse(
+        id=entity.id,
+        title=entity.title,
+        category=entity.category,
+        vault_path=vault_path,
+        final_score=round(score_result.final_score, 2),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@router.get("/search")
+async def search_entities(q: str, limit: int = 20, db: Database = Depends(get_db)) -> dict:
+    results = await db.search_entities(q, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.get("/top")
+async def top_entities(
+    limit: int = 20, category: Optional[str] = None, db: Database = Depends(get_db)
+) -> dict:
+    results = await db.get_top_entities(limit=limit, category=category)
+    return {"results": results, "count": len(results)}
+
+
+@router.get("/{entity_id}")
+async def get_entity(entity_id: str, db: Database = Depends(get_db)) -> dict:
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    out_refs, in_refs = await db.get_references(entity_id)
+    return {**entity, "outgoing_refs": out_refs, "incoming_refs": in_refs}

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -41,13 +41,13 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
     vault_path = entity.vault_path
     file_path = entity.file_path or str(config.VAULT_PATH / vault_path)
 
-    # Parse refs via Rust
+    # Parse refs via Rust (outside transaction — read-only)
     refs: list[str] = []
     if entity.content:
         refs_result = rust_client.parse_refs(entity.content, current_id=entity.id)
         refs = refs_result.refs
 
-    # Score via Rust
+    # Score via Rust (outside transaction — read-only computation)
     score_result = rust_client.compute_score(
         interest=entity.interest,
         strategy=entity.strategy,
@@ -55,8 +55,7 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
         last_boosted_at=now,
     )
 
-    # Persist entity
-    await db.upsert_entity({
+    entity_data = {
         "id": entity.id,
         "file_path": file_path,
         "vault_path": vault_path,
@@ -65,23 +64,25 @@ async def create_entity(entity: EntityCreate, db: Database = Depends(get_db)) ->
         "created_at": now,
         "updated_at": now,
         "metadata": entity.metadata,
-    })
+    }
 
-    # Persist score
-    await db.upsert_score({
+    score_data = {
         "entity_id": entity.id,
         "interest": entity.interest,
         "strategy": entity.strategy,
         "consensus": entity.consensus,
         "final_score": round(score_result.final_score, 2),
         "updated_at": now,
-    })
+    }
 
-    # Persist references
-    for ref_id in refs:
-        await db.upsert_reference(entity.id, ref_id)
-
-    await db.log_event(entity.id, "created", trigger="api")
+    # Atomic write: entity + score + refs + event all succeed or all rollback
+    await db.create_entity_full(
+        entity_data=entity_data,
+        score_data=score_data,
+        ref_ids=refs,
+        event_type="created",
+        event_trigger="api",
+    )
 
     return EntityResponse(
         id=entity.id,

--- a/compass-api/src/api/feed.py
+++ b/compass-api/src/api/feed.py
@@ -1,0 +1,26 @@
+"""Feed — daily digest of top entities."""
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from src.db.database import Database, get_db
+
+router = APIRouter(prefix="/feed", tags=["feed"])
+
+
+class FeedResponse(BaseModel):
+    top_inbox: list[dict]
+    recently_updated: list[dict]
+    strategic: list[dict]
+
+
+@router.get("/today", response_model=FeedResponse)
+async def daily_feed(limit: int = 10, db: Database = Depends(get_db)) -> FeedResponse:
+    top_inbox = await db.get_top_entities(limit=limit, category="Inbox")
+    recently = await db.get_top_entities(limit=limit)
+    strategic = await db.get_top_entities(limit=limit, category="Direction")
+
+    return FeedResponse(
+        top_inbox=top_inbox,
+        recently_updated=recently,
+        strategic=strategic,
+    )

--- a/compass-api/src/api/scores.py
+++ b/compass-api/src/api/scores.py
@@ -44,7 +44,7 @@ async def update_score(update: ScoreUpdate, db: Database = Depends(get_db)) -> S
         last_boosted_at=last_boosted,
     )
 
-    await db.upsert_score({
+    score_data = {
         "entity_id": update.entity_id,
         "interest": interest,
         "strategy": strategy,
@@ -52,16 +52,26 @@ async def update_score(update: ScoreUpdate, db: Database = Depends(get_db)) -> S
         "final_score": round(score_result.final_score, 2),
         "manual_override": update.manual_override,
         "updated_at": now,
-    })
+    }
 
-    if update.manual_override:
-        await db.conn.execute(
-            "UPDATE entities SET last_boosted_at = ? WHERE id = ?",
-            (now, update.entity_id),
+    # Atomic: score update + event log (both succeed or both rollback)
+    await db.begin()
+    try:
+        await db.upsert_score(score_data)
+        if update.manual_override:
+            await db.conn.execute(
+                "UPDATE entities SET last_boosted_at = ? WHERE id = ?",
+                (now, update.entity_id),
+            )
+        await db.log_event(
+            update.entity_id,
+            "score_updated",
+            trigger="manual" if update.manual_override else "auto",
         )
-        await db.conn.commit()
-
-    await db.log_event(update.entity_id, "score_updated", trigger="manual" if update.manual_override else "auto")
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
 
     return ScoreResponse(
         entity_id=update.entity_id,

--- a/compass-api/src/api/scores.py
+++ b/compass-api/src/api/scores.py
@@ -1,0 +1,71 @@
+"""REST endpoints for score management."""
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from src.db.database import Database, get_db
+from src.core.rust_client import rust_client
+
+router = APIRouter(prefix="/scores", tags=["scores"])
+
+
+class ScoreUpdate(BaseModel):
+    entity_id: str
+    interest: float | None = None
+    strategy: float | None = None
+    consensus: float | None = None
+    manual_override: bool = False
+
+
+class ScoreResponse(BaseModel):
+    entity_id: str
+    final_score: float
+    decay_factor: float
+    days_elapsed: float
+
+
+@router.post("/update", response_model=ScoreResponse)
+async def update_score(update: ScoreUpdate, db: Database = Depends(get_db)) -> ScoreResponse:
+    entity = await db.get_entity(update.entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    now = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    interest = update.interest if update.interest is not None else float(entity.get("interest", 5.0))
+    strategy = update.strategy if update.strategy is not None else float(entity.get("strategy", 5.0))
+    consensus = update.consensus if update.consensus is not None else float(entity.get("consensus", 0.0))
+    last_boosted = entity.get("last_boosted_at") or now
+
+    score_result = rust_client.compute_score(
+        interest=interest,
+        strategy=strategy,
+        consensus=consensus,
+        last_boosted_at=last_boosted,
+    )
+
+    await db.upsert_score({
+        "entity_id": update.entity_id,
+        "interest": interest,
+        "strategy": strategy,
+        "consensus": consensus,
+        "final_score": round(score_result.final_score, 2),
+        "manual_override": update.manual_override,
+        "updated_at": now,
+    })
+
+    if update.manual_override:
+        await db.conn.execute(
+            "UPDATE entities SET last_boosted_at = ? WHERE id = ?",
+            (now, update.entity_id),
+        )
+        await db.conn.commit()
+
+    await db.log_event(update.entity_id, "score_updated", trigger="manual" if update.manual_override else "auto")
+
+    return ScoreResponse(
+        entity_id=update.entity_id,
+        final_score=round(score_result.final_score, 2),
+        decay_factor=round(score_result.decay_factor, 4),
+        days_elapsed=round(score_result.days_elapsed, 1),
+    )

--- a/compass-api/src/config.py
+++ b/compass-api/src/config.py
@@ -1,0 +1,28 @@
+"""Application configuration — all env-driven, no magic constants."""
+from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+# Vault
+VAULT_PATH = Path(os.getenv("VAULT_PATH", "./vault"))
+
+# Rust binary
+RUST_BINARY_PATH = Path(os.getenv("RUST_BINARY_PATH", "./bin/compass_core"))
+
+# Database
+DB_PATH = Path(os.getenv("DB_PATH", "./data/compass.db"))
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+# FastAPI
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8000"))
+
+# OpenAI / Anthropic (for Agent SDK, Phase 1 optional)
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+
+# Feishu (optional, for bot)
+FEISHU_APP_ID = os.getenv("FEISHU_APP_ID")
+FEISHU_APP_SECRET = os.getenv("FEISHU_APP_SECRET")

--- a/compass-api/src/config.py
+++ b/compass-api/src/config.py
@@ -5,14 +5,32 @@ import os
 
 load_dotenv()
 
-# Vault
-VAULT_PATH = Path(os.getenv("VAULT_PATH", "./vault"))
+# Base directory (where this file lives — compass-api/src/)
+BASE_DIR = Path(__file__).parent.parent
 
-# Rust binary
-RUST_BINARY_PATH = Path(os.getenv("RUST_BINARY_PATH", "./bin/compass_core"))
+# Vault — resolved relative to BASE_DIR if not absolute
+_vault_env = os.getenv("VAULT_PATH", "")
+if _vault_env:
+    VAULT_PATH = Path(_vault_env) if Path(_vault_env).is_absolute() else (BASE_DIR / _vault_env)
+else:
+    VAULT_PATH = BASE_DIR / "vault"
+VAULT_PATH = VAULT_PATH.resolve()
+
+# Rust binary — resolved relative to BASE_DIR
+_rust_env = os.getenv("RUST_BINARY_PATH", "")
+if _rust_env:
+    RUST_BINARY_PATH = Path(_rust_env) if Path(_rust_env).is_absolute() else (BASE_DIR / _rust_env)
+else:
+    RUST_BINARY_PATH = BASE_DIR / "bin" / "compass_core"
+RUST_BINARY_PATH = RUST_BINARY_PATH.resolve()
 
 # Database
-DB_PATH = Path(os.getenv("DB_PATH", "./data/compass.db"))
+_db_env = os.getenv("DB_PATH", "")
+if _db_env:
+    DB_PATH = Path(_db_env) if Path(_db_env).is_absolute() else (BASE_DIR / _db_env)
+else:
+    DB_PATH = BASE_DIR / "data" / "compass.db"
+DB_PATH = DB_PATH.resolve()
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 # FastAPI
@@ -26,3 +44,16 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 # Feishu (optional, for bot)
 FEISHU_APP_ID = os.getenv("FEISHU_APP_ID")
 FEISHU_APP_SECRET = os.getenv("FEISHU_APP_SECRET")
+
+# ---- startup validation ----
+_missing: list[str] = []
+if not RUST_BINARY_PATH.exists():
+    _missing.append(f"RUST_BINARY_PATH not found: {RUST_BINARY_PATH}")
+if not VAULT_PATH.exists():
+    _missing.append(f"VAULT_PATH not found: {VAULT_PATH}")
+
+if _missing:
+    raise RuntimeError(
+        "Compass API startup errors:\n  " + "\n  ".join(_missing)
+        + "\n\nSet RUST_BINARY_PATH and VAULT_PATH in .env or environment."
+    )

--- a/compass-api/src/config.py
+++ b/compass-api/src/config.py
@@ -1,9 +1,11 @@
 """Application configuration — all env-driven, no magic constants."""
 from pathlib import Path
-from dotenv import load_dotenv
 import os
+from dotenv import load_dotenv
 
-load_dotenv()
+# Load .env from the same directory as this file (compass-api/src/)
+_src_dir = Path(__file__).parent.parent
+load_dotenv(_src_dir / ".env")
 
 # Base directory (where this file lives — compass-api/src/)
 BASE_DIR = Path(__file__).parent.parent

--- a/compass-api/src/core/__init__.py
+++ b/compass-api/src/core/__init__.py
@@ -1,0 +1,1 @@
+# Core modules

--- a/compass-api/src/core/rust_client.py
+++ b/compass-api/src/core/rust_client.py
@@ -1,0 +1,84 @@
+"""Python ↔ Rust subprocess JSON-RPC client."""
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from src import config as cfg
+
+
+@dataclass
+class ScoreResult:
+    final_score: float
+    decay_factor: float
+    days_elapsed: float
+
+
+@dataclass
+class RefsResult:
+    refs: list[str]
+
+
+class RustClient:
+    """Calls compass-core binary via JSON-RPC over stdin/stdout."""
+
+    def __init__(self, binary_path: Optional[Path] = None) -> None:
+        self.binary_path = str(binary_path or cfg.RUST_BINARY_PATH)
+
+    def _call(self, method: str, params: dict) -> dict:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        }
+        result = subprocess.run(
+            [self.binary_path],
+            input=json.dumps(payload).encode(),
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Rust binary error: {result.stderr.decode()}")
+        response = json.loads(result.stdout)
+        if "error" in response:
+            raise RuntimeError(f"JSON-RPC error: {response['error']}")
+        return response.get("result", {})
+
+    def compute_score(
+        self,
+        interest: float,
+        strategy: float,
+        consensus: float,
+        last_boosted_at: str,
+        interest_half_life_days: float = 30.0,
+        strategy_half_life_days: float = 365.0,
+        consensus_half_life_days: float = 60.0,
+    ) -> ScoreResult:
+        params = {
+            "interest": interest,
+            "strategy": strategy,
+            "consensus": consensus,
+            "last_boosted_at": last_boosted_at,
+            "interest_half_life_days": interest_half_life_days,
+            "strategy_half_life_days": strategy_half_life_days,
+            "consensus_half_life_days": consensus_half_life_days,
+        }
+        result = self._call("compute_score", params)
+        return ScoreResult(
+            final_score=result["final_score"],
+            decay_factor=result["decay_factor"],
+            days_elapsed=result["days_elapsed"],
+        )
+
+    def parse_refs(self, content: str, current_id: Optional[str] = None) -> RefsResult:
+        params = {"content": content, "current_entity_id": current_id}
+        result = self._call("parse_refs", params)
+        return RefsResult(refs=result.get("refs", []))
+
+
+# Singleton instance
+rust_client = RustClient()

--- a/compass-api/src/db/__init__.py
+++ b/compass-api/src/db/__init__.py
@@ -1,0 +1,1 @@
+# DB module

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -1,8 +1,8 @@
 """SQLite database manager — async aiosqlite, WAL mode."""
 from __future__ import annotations
 
-import asyncio
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -17,20 +17,23 @@ async def init_db(db_path: Optional[Path] = None) -> aiosqlite.Connection:
     """Open DB, run schema, return connection (caller owns it)."""
     path = db_path or cfg.DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = await aiosqlite.connect(str(path))
+    conn = await aiosqlite.connect(str(path), isolation_level=None)
     conn.row_factory = aiosqlite.Row
     # WAL + foreign keys
     await conn.execute("PRAGMA journal_mode=WAL")
     await conn.execute("PRAGMA foreign_keys=ON")
-    # Schema
+    # Schema (includes FTS triggers)
     schema = SCHEMA_PATH.read_text()
     await conn.executescript(schema)
-    await conn.commit()
     return conn
 
 
 class Database:
-    """Thin async wrapper around aiosqlite — one connection per Database instance."""
+    """Thin async wrapper around aiosqlite — one connection per Database instance.
+
+    Caller is responsible for explicit transaction control via begin()/commit()/rollback().
+    This allows wrapping multiple operations atomically.
+    """
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
         self.db_path = db_path or cfg.DB_PATH
@@ -50,9 +53,24 @@ class Database:
             raise RuntimeError("Database not connected — call .connect() first")
         return self._conn
 
+    # ---- explicit transaction control ----
+
+    async def begin(self) -> None:
+        """Begin a transaction (EXCLUSIVE for writes)."""
+        await self.conn.execute("BEGIN EXCLUSIVE")
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        await self.conn.execute("COMMIT")
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        await self.conn.execute("ROLLBACK")
+
     # ---- entities ----
 
     async def upsert_entity(self, data: dict[str, Any]) -> None:
+        """Insert or update an entity. Caller manages transaction."""
         await self.conn.execute(
             """
             INSERT INTO entities (id, file_path, vault_path, title, category,
@@ -84,9 +102,10 @@ class Database:
                 "metadata": json.dumps(data.get("metadata", {})),
             },
         )
-        await self.conn.commit()
+        # NOTE: no commit() here — caller controls transaction
 
     async def upsert_score(self, data: dict[str, Any]) -> None:
+        """Insert or update a score. Caller manages transaction."""
         await self.conn.execute(
             """
             INSERT INTO scores (entity_id, interest, strategy, consensus,
@@ -118,7 +137,59 @@ class Database:
                 "updated_at": data["updated_at"],
             },
         )
-        await self.conn.commit()
+        # NOTE: no commit() here — caller controls transaction
+
+    async def upsert_reference(self, source_id: str, target_id: str) -> None:
+        """Insert a reference (source→target). FK check disabled intentionally:
+        target may not exist yet (forward link to future note).
+        Caller manages transaction."""
+        now = datetime.utcnow().isoformat() + "Z"
+        await self.conn.execute("PRAGMA foreign_keys=OFF")
+        try:
+            await self.conn.execute(
+                'INSERT OR IGNORE INTO "references" (source_id, target_id, created_at) VALUES (?, ?, ?)',
+                (source_id, target_id, now),
+            )
+        finally:
+            await self.conn.execute("PRAGMA foreign_keys=ON")
+        # NOTE: no commit() here — caller controls transaction
+
+    async def log_event(
+        self, entity_id: str, event_type: str, trigger: Optional[str] = None
+    ) -> None:
+        """Log a timeline event. Caller manages transaction."""
+        now = datetime.utcnow().isoformat() + "Z"
+        await self.conn.execute(
+            "INSERT INTO timeline_events (entity_id, event_type, trigger, created_at) VALUES (?, ?, ?, ?)",
+            (entity_id, event_type, trigger, now),
+        )
+        # NOTE: no commit() here — caller controls transaction
+
+    # ---- atomic create (all-or-nothing) ----
+
+    async def create_entity_full(
+        self,
+        entity_data: dict[str, Any],
+        score_data: dict[str, Any],
+        ref_ids: list[str],
+        event_type: str = "created",
+        event_trigger: str = "api",
+    ) -> None:
+        """Atomically create entity + score + references + event in one transaction.
+        Raises on any failure; rolls back entirely on error."""
+        await self.begin()
+        try:
+            await self.upsert_entity(entity_data)
+            await self.upsert_score(score_data)
+            for ref_id in ref_ids:
+                await self.upsert_reference(entity_data["id"], ref_id)
+            await self.log_event(entity_data["id"], event_type, event_trigger)
+            await self.commit()
+        except Exception:
+            await self.rollback()
+            raise
+
+    # ---- read operations ----
 
     async def get_entity(self, entity_id: str) -> Optional[dict[str, Any]]:
         async with self.conn.execute(
@@ -183,29 +254,6 @@ class Database:
             [r["target_id"] for r in out_rows],
             [r["source_id"] for r in in_rows],
         )
-
-    async def upsert_reference(self, source_id: str, target_id: str) -> None:
-        from datetime import datetime
-        now = datetime.utcnow().isoformat() + "Z"
-        # Disable FK check — target may not exist yet (backlink to future note)
-        await self.conn.execute("PRAGMA foreign_keys=OFF")
-        await self.conn.execute(
-            'INSERT OR IGNORE INTO "references" (source_id, target_id, created_at) VALUES (?, ?, ?)',
-            (source_id, target_id, now),
-        )
-        await self.conn.execute("PRAGMA foreign_keys=ON")
-        await self.conn.commit()
-
-    async def log_event(
-        self, entity_id: str, event_type: str, trigger: Optional[str] = None
-    ) -> None:
-        from datetime import datetime
-        now = datetime.utcnow().isoformat() + "Z"
-        await self.conn.execute(
-            "INSERT INTO timeline_events (entity_id, event_type, trigger, created_at) VALUES (?, ?, ?, ?)",
-            (entity_id, event_type, trigger, now),
-        )
-        await self.conn.commit()
 
 
 # ---- FastAPI dependency ----

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -1,0 +1,225 @@
+"""SQLite database manager — async aiosqlite, WAL mode."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import aiosqlite
+
+from src import config as cfg
+
+SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+
+
+async def init_db(db_path: Optional[Path] = None) -> aiosqlite.Connection:
+    """Open DB, run schema, return connection (caller owns it)."""
+    path = db_path or cfg.DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = await aiosqlite.connect(str(path))
+    conn.row_factory = aiosqlite.Row
+    # WAL + foreign keys
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("PRAGMA foreign_keys=ON")
+    # Schema
+    schema = SCHEMA_PATH.read_text()
+    await conn.executescript(schema)
+    await conn.commit()
+    return conn
+
+
+class Database:
+    """Thin async wrapper around aiosqlite — one connection per Database instance."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self.db_path = db_path or cfg.DB_PATH
+        self._conn: Optional[aiosqlite.Connection] = None
+
+    async def connect(self) -> None:
+        self._conn = await init_db(self.db_path)
+
+    async def close(self) -> None:
+        if self._conn:
+            await self._conn.close()
+            self._conn = None
+
+    @property
+    def conn(self) -> aiosqlite.Connection:
+        if self._conn is None:
+            raise RuntimeError("Database not connected — call .connect() first")
+        return self._conn
+
+    # ---- entities ----
+
+    async def upsert_entity(self, data: dict[str, Any]) -> None:
+        await self.conn.execute(
+            """
+            INSERT INTO entities (id, file_path, vault_path, title, category,
+                                   created_at, updated_at, last_boosted_at,
+                                   has_attachments, attachment_refs, metadata)
+            VALUES (:id, :file_path, :vault_path, :title, :category,
+                    :created_at, :updated_at, :last_boosted_at,
+                    :has_attachments, :attachment_refs, :metadata)
+            ON CONFLICT(id) DO UPDATE SET
+                title = excluded.title,
+                category = excluded.category,
+                updated_at = excluded.updated_at,
+                last_boosted_at = excluded.last_boosted_at,
+                has_attachments = excluded.has_attachments,
+                attachment_refs = excluded.attachment_refs,
+                metadata = excluded.metadata
+            """,
+            {
+                "id": data["id"],
+                "file_path": data["file_path"],
+                "vault_path": data["vault_path"],
+                "title": data["title"],
+                "category": data.get("category", "Inbox"),
+                "created_at": data["created_at"],
+                "updated_at": data["updated_at"],
+                "last_boosted_at": data.get("last_boosted_at"),
+                "has_attachments": int(data.get("has_attachments", False)),
+                "attachment_refs": json.dumps(data.get("attachment_refs", [])),
+                "metadata": json.dumps(data.get("metadata", {})),
+            },
+        )
+        await self.conn.commit()
+
+    async def upsert_score(self, data: dict[str, Any]) -> None:
+        await self.conn.execute(
+            """
+            INSERT INTO scores (entity_id, interest, strategy, consensus,
+                                final_score, interest_half_life_days,
+                                strategy_half_life_days, consensus_half_life_days,
+                                manual_override, updated_at)
+            VALUES (:entity_id, :interest, :strategy, :consensus,
+                    :final_score, :interest_half_life_days,
+                    :strategy_half_life_days, :consensus_half_life_days,
+                    :manual_override, :updated_at)
+            ON CONFLICT(entity_id) DO UPDATE SET
+                interest = excluded.interest,
+                strategy = excluded.strategy,
+                consensus = excluded.consensus,
+                final_score = excluded.final_score,
+                manual_override = excluded.manual_override,
+                updated_at = excluded.updated_at
+            """,
+            {
+                "entity_id": data["entity_id"],
+                "interest": data.get("interest", 5.0),
+                "strategy": data.get("strategy", 5.0),
+                "consensus": data.get("consensus", 0.0),
+                "final_score": data.get("final_score", 0.0),
+                "interest_half_life_days": data.get("interest_half_life_days", 30.0),
+                "strategy_half_life_days": data.get("strategy_half_life_days", 365.0),
+                "consensus_half_life_days": data.get("consensus_half_life_days", 60.0),
+                "manual_override": int(data.get("manual_override", False)),
+                "updated_at": data["updated_at"],
+            },
+        )
+        await self.conn.commit()
+
+    async def get_entity(self, entity_id: str) -> Optional[dict[str, Any]]:
+        async with self.conn.execute(
+            "SELECT * FROM entities WHERE id = ?", (entity_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        return dict(row) if row else None
+
+    async def search_entities(
+        self, query: str, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        cur = await self.conn.execute(
+            """
+            SELECT e.*, s.final_score
+            FROM entities_fts f
+            JOIN entities e ON e.id = f.id
+            LEFT JOIN scores s ON s.entity_id = e.id
+            WHERE entities_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (query, limit),
+        )
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
+    async def get_top_entities(
+        self, limit: int = 20, category: Optional[str] = None
+    ) -> list[dict[str, Any]]:
+        q = """
+            SELECT e.*, s.final_score
+            FROM entities e
+            LEFT JOIN scores s ON s.entity_id = e.id
+        """
+        params: list[Any] = []
+        if category:
+            q += " WHERE e.category = ?"
+            params.append(category)
+        q += " ORDER BY s.final_score DESC LIMIT ?"
+        params.append(limit)
+        cur = await self.conn.execute(q, params)
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
+    async def get_references(
+        self, entity_id: str
+    ) -> tuple[list[str], list[str]]:
+        """Return (outgoing_refs, incoming_refs) ids for entity."""
+        out_cur = await self.conn.execute(
+            'SELECT target_id FROM "references" WHERE source_id = ?',
+            (entity_id,),
+        )
+        out_rows = await out_cur.fetchall()
+
+        in_cur = await self.conn.execute(
+            'SELECT source_id FROM "references" WHERE target_id = ?',
+            (entity_id,),
+        )
+        in_rows = await in_cur.fetchall()
+
+        return (
+            [r["target_id"] for r in out_rows],
+            [r["source_id"] for r in in_rows],
+        )
+
+    async def upsert_reference(self, source_id: str, target_id: str) -> None:
+        from datetime import datetime
+        now = datetime.utcnow().isoformat() + "Z"
+        # Disable FK check — target may not exist yet (backlink to future note)
+        await self.conn.execute("PRAGMA foreign_keys=OFF")
+        await self.conn.execute(
+            'INSERT OR IGNORE INTO "references" (source_id, target_id, created_at) VALUES (?, ?, ?)',
+            (source_id, target_id, now),
+        )
+        await self.conn.execute("PRAGMA foreign_keys=ON")
+        await self.conn.commit()
+
+    async def log_event(
+        self, entity_id: str, event_type: str, trigger: Optional[str] = None
+    ) -> None:
+        from datetime import datetime
+        now = datetime.utcnow().isoformat() + "Z"
+        await self.conn.execute(
+            "INSERT INTO timeline_events (entity_id, event_type, trigger, created_at) VALUES (?, ?, ?, ?)",
+            (entity_id, event_type, trigger, now),
+        )
+        await self.conn.commit()
+
+
+# ---- FastAPI dependency ----
+
+_db_instance: Database | None = None
+
+
+def set_db(db: Database) -> None:
+    global _db_instance
+    _db_instance = db
+
+
+def get_db() -> Database:
+    """FastAPI dependency — returns the shared DB instance."""
+    if _db_instance is None:
+        raise RuntimeError("Database not initialized — call set_db() first")
+    return _db_instance

--- a/compass-api/src/db/schema.sql
+++ b/compass-api/src/db/schema.sql
@@ -1,0 +1,69 @@
+-- Compass SQLite Schema
+-- SQLite WAL mode, FTS5 enabled
+
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+-- Entities (one per Obsidian note)
+CREATE TABLE IF NOT EXISTS entities (
+    id              TEXT PRIMARY KEY,
+    file_path       TEXT NOT NULL UNIQUE,
+    vault_path      TEXT NOT NULL,
+    title           TEXT NOT NULL,
+    category        TEXT NOT NULL DEFAULT 'Inbox',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    last_boosted_at TEXT,
+    has_attachments INTEGER DEFAULT 0,
+    attachment_refs TEXT,
+    metadata        TEXT
+);
+
+-- Scores per entity
+CREATE TABLE IF NOT EXISTS scores (
+    entity_id                   TEXT PRIMARY KEY REFERENCES entities(id),
+    interest                     REAL DEFAULT 5.0,
+    strategy                      REAL DEFAULT 5.0,
+    consensus                     REAL DEFAULT 0.0,
+    final_score                  REAL DEFAULT 0.0,
+    interest_half_life_days       REAL DEFAULT 30.0,
+    strategy_half_life_days       REAL DEFAULT 365.0,
+    consensus_half_life_days      REAL DEFAULT 60.0,
+    manual_override               INTEGER DEFAULT 0,
+    updated_at                    TEXT NOT NULL
+);
+
+-- Bidirectional references
+CREATE TABLE IF NOT EXISTS "references" (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id   TEXT NOT NULL REFERENCES entities(id),
+    target_id   TEXT NOT NULL REFERENCES entities(id),
+    created_at  TEXT NOT NULL,
+    UNIQUE(source_id, target_id)
+);
+
+-- Timeline events
+CREATE TABLE IF NOT EXISTS timeline_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id   TEXT NOT NULL REFERENCES entities(id),
+    event_type  TEXT NOT NULL,
+    trigger     TEXT,
+    created_at  TEXT NOT NULL
+);
+
+-- FTS5 full-text search
+CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+    id,
+    title,
+    content,
+    category,
+    content='entities',
+    content_rowid='rowid'
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_entities_category ON entities(category);
+CREATE INDEX IF NOT EXISTS idx_scores_final_score ON scores(final_score DESC);
+CREATE INDEX IF NOT EXISTS idx_references_source ON "references"(source_id);
+CREATE INDEX IF NOT EXISTS idx_references_target ON "references"(target_id);
+CREATE INDEX IF NOT EXISTS idx_timeline_entity ON timeline_events(entity_id);

--- a/compass-api/src/db/schema.sql
+++ b/compass-api/src/db/schema.sql
@@ -1,5 +1,5 @@
 -- Compass SQLite Schema
--- SQLite WAL mode, FTS5 enabled
+-- SQLite WAL mode, FTS5 + sync triggers
 
 PRAGMA journal_mode=WAL;
 PRAGMA foreign_keys=ON;
@@ -34,10 +34,12 @@ CREATE TABLE IF NOT EXISTS scores (
 );
 
 -- Bidirectional references
+-- FK on source_id enforced, target_id intentionally unconstrained
+-- (a note may reference a future note not yet in the system)
 CREATE TABLE IF NOT EXISTS "references" (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     source_id   TEXT NOT NULL REFERENCES entities(id),
-    target_id   TEXT NOT NULL REFERENCES entities(id),
+    target_id   TEXT NOT NULL,
     created_at  TEXT NOT NULL,
     UNIQUE(source_id, target_id)
 );
@@ -51,14 +53,11 @@ CREATE TABLE IF NOT EXISTS timeline_events (
     created_at  TEXT NOT NULL
 );
 
--- FTS5 full-text search
+-- FTS5 full-text search (plain — triggers handle sync manually)
 CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
     id,
     title,
-    content,
-    category,
-    content='entities',
-    content_rowid='rowid'
+    category
 );
 
 -- Indexes
@@ -67,3 +66,24 @@ CREATE INDEX IF NOT EXISTS idx_scores_final_score ON scores(final_score DESC);
 CREATE INDEX IF NOT EXISTS idx_references_source ON "references"(source_id);
 CREATE INDEX IF NOT EXISTS idx_references_target ON "references"(target_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_entity ON timeline_events(entity_id);
+
+-- FTS5 sync triggers (keep full-text index consistent with entities table)
+CREATE TRIGGER IF NOT EXISTS entities_fts_insert
+AFTER INSERT ON entities BEGIN
+    INSERT INTO entities_fts(id, title, category)
+    VALUES (new.id, new.title, new.category);
+END;
+
+CREATE TRIGGER IF NOT EXISTS entities_fts_delete
+AFTER DELETE ON entities BEGIN
+    INSERT INTO entities_fts(entities_fts, id, title, category)
+    VALUES ('delete', old.id, old.title, old.category);
+END;
+
+CREATE TRIGGER IF NOT EXISTS entities_fts_update
+AFTER UPDATE ON entities BEGIN
+    INSERT INTO entities_fts(entities_fts, id, title, category)
+    VALUES ('delete', old.id, old.title, old.category);
+    INSERT INTO entities_fts(id, title, category)
+    VALUES (new.id, new.title, new.category);
+END;

--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -1,0 +1,46 @@
+"""Compass API — FastAPI entry point."""
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import FastAPI
+
+from src import config
+from src.db.database import Database, set_db
+from src.api import entities, scores, feed, agent
+
+# Global DB — initialized once at startup
+db = Database()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await db.connect()
+    set_db(db)  # register the shared instance for Depends()
+    print(f"[Compass API] DB ready at {config.DB_PATH}")
+    print(f"[Compass API] Vault at {config.VAULT_PATH}")
+    print(f"[Compass API] Rust binary at {config.RUST_BINARY_PATH}")
+    yield
+    await db.close()
+    print("[Compass API] Shutdown complete")
+
+
+app = FastAPI(
+    title="Compass API",
+    description="Python glue layer — compass-core (Rust) + FastAPI + SQLite",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+app.include_router(entities.router)
+app.include_router(scores.router)
+app.include_router(feed.router)
+app.include_router(agent.router)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "vault": str(config.VAULT_PATH)}
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host=config.HOST, port=config.PORT, reload=False)

--- a/compass-api/src/services/__init__.py
+++ b/compass-api/src/services/__init__.py
@@ -1,0 +1,1 @@
+# Services module

--- a/compass-api/src/services/filewatcher.py
+++ b/compass-api/src/services/filewatcher.py
@@ -1,0 +1,400 @@
+"""FileWatcher — monitors vault directory, keeps Compass API in sync.
+
+Events (create / modify / delete) are coalesced with a 500 ms debounce window
+so rapid file saves bundle into a single API call.
+
+Startup behaviour:
+  1. Walk the entire vault and POST / PUT every *.md file found.
+     This catches files modified while the watcher was not running.
+  2. Register the watchdog observer and enter the event loop.
+
+Entity ID mapping
+-----------------
+Entity IDs are derived from the vault-relative file path by stripping the
+extension and replacing path separators with hyphens:
+
+  Inbox/daily-2026-04-06.md  →  inbox-daily-2026-04-06
+  Projects/compass.md        →  projects-compass
+
+This must match what users write in [[wiki-links]] so that FileWatcher and
+the Rust reference parser agree on IDs.
+
+Frontmatter expected fields
+---------------------------
+  title       (str)  — entity title; defaults to sanitized filename
+  category    (str)  — defaults to "Inbox"
+  interest    (float) — 0-10 scale, default 5.0
+  strategy    (float) — 0-10 scale, default 5.0
+  consensus   (float) — 0-10 scale, default 0.0
+  tags        (list[str]) — stored in metadata
+  Any additional fields are stored verbatim in metadata.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import frontmatter
+import httpx
+from watchdog.observers import Observer
+from watchdog.events import (
+    FileSystemEvent,
+    FileSystemEventHandler,
+    FileCreatedEvent,
+    FileModifiedEvent,
+    FileDeletedEvent,
+    FileMovedEvent,
+)
+
+from src import config
+
+# ---- entity ID helpers ----
+
+_STRIP_EXT_RE = re.compile(r"\.(md|MD|markdown|MARKDOWN)$")
+_MULTI_DASH_RE = re.compile(r"-+")
+
+
+def vault_path_to_entity_id(vault_path: str) -> str:
+    """Stable entity ID derived from vault-relative path.
+
+    Examples:
+      Inbox/daily-2026-04-06.md  →  inbox-daily-2026-04-06
+      Projects/compass_v2.md     →  projects-compass_v2
+    """
+    # Remove file extension
+    stem = _STRIP_EXT_RE.sub("", vault_path)
+    # Replace / and \ with -
+    stem = stem.replace("/", "-").replace("\\", "-")
+    # Collapse multiple dashes
+    stem = _MULTI_DASH_RE.sub("-", stem)
+    # Strip leading/trailing dashes
+    stem = stem.strip("-")
+    return stem.lower()
+
+
+# ---- frontmatter parsing ----
+
+class ParsedFile:
+    """Decoded frontmatter + body from a vault markdown file."""
+
+    def __init__(
+        self,
+        vault_path: str,
+        entity_id: str,
+        title: str,
+        category: str,
+        interest: float,
+        strategy: float,
+        consensus: float,
+        content: Optional[str],
+        metadata: dict,
+    ):
+        self.vault_path = vault_path
+        self.entity_id = entity_id
+        self.title = title
+        self.category = category
+        self.interest = interest
+        self.strategy = strategy
+        self.consensus = consensus
+        self.content = content  # markdown body for ref extraction
+        self.metadata = metadata
+
+    def to_api_payload(self) -> dict:
+        """Build the POST / PUT request body."""
+        return {
+            "id": self.entity_id,
+            "title": self.title,
+            "category": self.category,
+            "vault_path": self.vault_path,
+            "interest": self.interest,
+            "strategy": self.strategy,
+            "consensus": self.consensus,
+            "content": self.content,
+            "metadata": self.metadata,
+        }
+
+
+def parse_markdown_file(path: Path, vault_path: str) -> Optional[ParsedFile]:
+    """Parse a markdown file, extracting frontmatter and body.
+
+    Returns None if the file cannot be read or has no frontmatter.
+    Uses frontmatter.load() which accepts a filename string.
+    """
+    try:
+        # frontmatter.load() accepts a filename string (or file object)
+        post = frontmatter.load(str(path))
+    except Exception as exc:
+        return None
+
+    metadata: dict = dict(post.metadata)  # pyfrontmatter Post stores metadata
+    body = post.content or ""
+
+    entity_id = vault_path_to_entity_id(vault_path)
+
+    title = str(metadata.pop("title", ""))
+    if not title:
+        # Fallback to filename without extension
+        title = _STRIP_EXT_RE.sub("", Path(vault_path).name)
+
+    category = str(metadata.pop("category", "Inbox"))
+    interest = float(metadata.pop("interest", 5.0))
+    strategy = float(metadata.pop("strategy", 5.0))
+    consensus = float(metadata.pop("consensus", 0.0))
+
+    # Store remaining keys in metadata
+    extra = dict(metadata)
+
+    return ParsedFile(
+        vault_path=vault_path,
+        entity_id=entity_id,
+        title=title,
+        category=category,
+        interest=interest,
+        strategy=strategy,
+        consensus=consensus,
+        content=body,
+        metadata=extra,
+    )
+
+
+# ---- API client ----
+
+_API_CLIENT: Optional[httpx.AsyncClient] = None
+
+
+def get_client() -> httpx.AsyncClient:
+    global _API_CLIENT
+    if _API_CLIENT is None:
+        _API_CLIENT = httpx.AsyncClient(
+            base_url=f"http://{config.HOST}:{config.PORT}",
+            timeout=10.0,
+        )
+    return _API_CLIENT
+
+
+async def close_client() -> None:
+    global _API_CLIENT
+    if _API_CLIENT:
+        await _API_CLIENT.aclose()
+        _API_CLIENT = None
+
+
+async def api_upsert(parsed: ParsedFile) -> None:
+    """POST (create) or PUT (update) an entity."""
+    client = get_client()
+    payload = parsed.to_api_payload()
+    # Try PUT first (update). If entity doesn't exist, 404 → fall back to POST.
+    resp = await client.put(f"/entities/{parsed.entity_id}", json=payload)
+    if resp.status_code == 404:
+        resp = await client.post("/entities", json=payload)
+    resp.raise_for_status()
+
+
+async def api_delete(entity_id: str) -> None:
+    """DELETE an entity. 404 is treated as success (already gone)."""
+    client = get_client()
+    resp = await client.delete(f"/entities/{entity_id}")
+    if resp.status_code != 404:
+        resp.raise_for_status()
+
+
+# ---- coalescing event queue ----
+
+class EventQueue:
+    """Coalescing event buffer.
+
+    Multiple watchdog events for the same path within `delay` seconds
+    are collapsed to the most recent event type.
+    EventHandler writes to it (from watchdog thread);
+    the poll loop reads from it (from asyncio event loop).
+
+    Uses threading.Lock because watchdog calls push() from its own thread,
+    not from the asyncio event loop.
+    """
+
+    def __init__(self, delay: float = 0.5) -> None:
+        self.delay = delay
+        self._events: dict[str, tuple[str, float]] = {}  # path → (type, timestamp)
+        self._lock = threading.Lock()
+
+    def push(self, path: str, event_type: str) -> None:
+        """Called from the watchdog thread — safe to call from any thread."""
+        with self._lock:
+            self._events[path] = (event_type, time.monotonic())
+
+    async def drain(self) -> list[tuple[str, str]]:
+        """Return and clear all events older than self.delay seconds.
+
+        threading.Lock.acquire() is blocking, so we run it in a thread pool
+        to avoid blocking the asyncio event loop.
+        """
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._lock.acquire)
+        try:
+            now = time.monotonic()
+            out: list[tuple[str, str]] = []
+            for path, (etype, ts) in list(self._events.items()):
+                if now - ts >= self.delay:
+                    out.append((path, etype))
+                    del self._events[path]
+            return out
+        finally:
+            self._lock.release()
+
+
+# ---- watchdog event handler ----
+
+_QUEUE: Optional[EventQueue] = None
+
+
+def set_queue(q: EventQueue) -> None:
+    global _QUEUE
+    _QUEUE = q
+
+
+def _enqueue(path: str, event_type: str) -> None:
+    if _QUEUE is not None:
+        _QUEUE.push(path, event_type)
+
+
+class VaultHandler(FileSystemEventHandler):
+    """Watches the vault root and enqueues events for any *.md change."""
+
+    def __init__(self, vault_path: Path) -> None:
+        self.vault_path = vault_path.resolve()
+
+    def _md_path(self, path: str) -> Optional[str]:
+        p = Path(path).resolve()
+        try:
+            p.relative_to(self.vault_path)
+        except ValueError:
+            return None
+        if p.suffix.lower() in (".md", ".markdown"):
+            return str(p.relative_to(self.vault_path))
+        return None
+
+    def on_created(self, event: FileCreatedEvent) -> None:
+        vp = self._md_path(event.src_path)
+        if vp:
+            _enqueue(vp, "create")
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if isinstance(event, FileModifiedEvent):
+            vp = self._md_path(event.src_path)
+            if vp:
+                _enqueue(vp, "update")
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if isinstance(event, FileDeletedEvent):
+            vp = self._md_path(event.src_path)
+            if vp:
+                _enqueue(vp, "delete")
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        # A move is delete + create from our perspective
+        if isinstance(event, FileMovedEvent):
+            old_vp = self._md_path(event.src_path)
+            new_vp = self._md_path(event.dest_path)
+            if old_vp:
+                _enqueue(old_vp, "delete")
+            if new_vp:
+                _enqueue(new_vp, "create")
+
+
+# ---- vault scan ----
+
+async def scan_vault() -> list[ParsedFile]:
+    """Walk the entire vault and parse every markdown file."""
+    vault = config.VAULT_PATH
+    results: list[ParsedFile] = []
+    if not vault.exists():
+        print(f"[FileWatcher] Vault not found: {vault}")
+        return results
+    for path in vault.rglob("*.md"):
+        vp = str(path.relative_to(vault))
+        parsed = parse_markdown_file(path, vp)
+        if parsed:
+            results.append(parsed)
+    for path in vault.rglob("*.markdown"):
+        vp = str(path.relative_to(vault))
+        parsed = parse_markdown_file(path, vp)
+        if parsed:
+            results.append(parsed)
+    return results
+
+
+async def full_sync() -> None:
+    """Full vault scan: upsert every file. Used on startup."""
+    files = await scan_vault()
+    print(f"[FileWatcher] Full sync: {len(files)} files found")
+    for parsed in files:
+        try:
+            await api_upsert(parsed)
+            print(f"  [synced]   {parsed.vault_path} → {parsed.entity_id}")
+        except Exception as exc:
+            print(f"  [error]    {parsed.vault_path}: {exc}")
+
+
+# ---- main loop ----
+
+async def process_events(queue: EventQueue) -> None:
+    """Poll the coalescing queue and dispatch to the API."""
+    while True:
+        await asyncio.sleep(queue.delay)
+        events = await queue.drain()
+        for vault_path, etype in events:
+            entity_id = vault_path_to_entity_id(vault_path)
+            if etype == "delete":
+                print(f"[FileWatcher] delete {vault_path}")
+                try:
+                    await api_delete(entity_id)
+                except Exception as exc:
+                    print(f"  [error] delete {entity_id}: {exc}")
+            else:
+                # create or update — re-parse the file and upsert
+                full_path = config.VAULT_PATH / vault_path
+                if not full_path.exists():
+                    print(f"[FileWatcher] skip (gone) {vault_path}")
+                    continue
+                parsed = parse_markdown_file(full_path, vault_path)
+                if not parsed:
+                    print(f"[FileWatcher] skip (parse error) {vault_path}")
+                    continue
+                print(f"[FileWatcher] {etype} {vault_path} → {entity_id}")
+                try:
+                    await api_upsert(parsed)
+                except Exception as exc:
+                    print(f"  [error] upsert {entity_id}: {exc}")
+
+
+def run_watcher() -> None:
+    """Entry point: start the watchdog observer (blocking)."""
+    vault = config.VAULT_PATH
+    if not vault.exists():
+        raise RuntimeError(f"VAULT_PATH does not exist: {vault}")
+
+    queue = EventQueue(delay=0.5)
+    set_queue(queue)
+
+    handler = VaultHandler(vault)
+    observer = Observer()
+    observer.schedule(handler, str(vault), recursive=True)
+    observer.start()
+    print(f"[FileWatcher] Watching {vault} (recursive)")
+
+    # Run the async event processor in the event loop
+    try:
+        asyncio.run(process_events(queue))
+    finally:
+        observer.stop()
+        observer.join()
+        asyncio.run(close_client())
+
+
+if __name__ == "__main__":
+    run_watcher()

--- a/compass-core/src/reference.rs
+++ b/compass-core/src/reference.rs
@@ -14,21 +14,52 @@ pub struct ReferenceParser;
 impl ReferenceParser {
     /// Extract all unique [[id]] references from content.
     /// If `current_entity_id` is provided, filters out self-references.
+    ///
+    /// Normalization pipeline (mirrors Python's vault_path_to_entity_id):
+    ///   1. lowercase
+    ///   2. replace '/' with '-'
+    ///   3. collapse multiple dashes
+    ///
+    /// This ensures [[Projects/compass-v2]] normalizes to "projects-compass-v2"
+    /// and matches the entity_id derived from the file path.
     pub fn extract_ids(content: &str, current_entity_id: Option<&str>) -> Vec<String> {
         let re = &*REF_RE;
 
         let mut ids: Vec<String> = re
             .captures_iter(content)
-            .map(|cap| cap.get(1).unwrap().as_str().to_string())
+            .map(|cap| {
+                let raw = cap.get(1).unwrap().as_str();
+                // Normalize: lowercase, replace '/' with '-', collapse dashes
+                let normalized = raw
+                    .to_lowercase()
+                    .replace('/', "-")
+                    .replace('\\', "-");
+                // Collapse multiple dashes
+                let mut result = String::new();
+                let mut prev_dash = false;
+                for ch in normalized.chars() {
+                    if ch == '-' {
+                        if !prev_dash {
+                            result.push(ch);
+                            prev_dash = true;
+                        }
+                    } else {
+                        result.push(ch);
+                        prev_dash = false;
+                    }
+                }
+                result.trim_matches('-').to_string()
+            })
             .collect();
 
         // Deduplicate
         ids.sort();
         ids.dedup();
 
-        // Filter self-reference if specified
+        // Filter self-reference if specified (normalized already)
         if let Some(self_id) = current_entity_id {
-            ids.retain(|id| id != self_id);
+            let normalized_self = self_id.to_lowercase();
+            ids.retain(|id| id != &normalized_self);
         }
 
         ids
@@ -47,9 +78,9 @@ mod tests {
 
     #[test]
     fn test_reference_extraction() {
-        let content = "这是 [[entity-001]] 和 [[entity-002]] 的核心观点";
+        let content = "这是 [[entity-001]] 和 [[Entity-002]] 的核心观点";
         let refs = ReferenceParser::extract_ids(content, None);
-        assert_eq!(refs, vec!["entity-001", "entity-002"]);
+        assert_eq!(refs, vec!["entity-001", "entity-002"]);  // all lowercase
     }
 
     #[test]
@@ -60,9 +91,19 @@ mod tests {
     }
 
     #[test]
+    fn test_self_reference_case_insensitive() {
+        // case mismatch: content has "Entity-001", entity_id is "entity-001"
+        // should still be filtered because both are normalized to lowercase
+        let content = "关于 [[Entity-001]] 的讨论";
+        let refs = ReferenceParser::extract_ids(content, Some("entity-001"));
+        assert!(refs.is_empty(), "case-insensitive self-ref should be filtered");
+    }
+
+    #[test]
     fn test_duplicate_refs_deduplicated() {
-        let content = "[[id1]] 和 [[id1]] 和 [[id2]]";
+        let content = "[[id1]] 和 [[ID1]] 和 [[id2]]";
         let refs = ReferenceParser::extract_ids(content, None);
+        // case-insensitive dedup: "id1" and "ID1" collapse to "id1"
         assert_eq!(refs, vec!["id1", "id2"]);
     }
 
@@ -78,5 +119,21 @@ mod tests {
         let content = "参考 [[comp_v2-2026_04-01]] 这个实体";
         let refs = ReferenceParser::extract_ids(content, None);
         assert_eq!(refs, vec!["comp_v2-2026_04-01"]);
+    }
+
+    #[test]
+    fn test_cross_folder_wiki_link() {
+        let content = "参考 [[Projects/compass-v2]] 这个实体";
+        let refs = ReferenceParser::extract_ids(content, None);
+        assert_eq!(refs, vec!["projects-compass-v2"]);  // / → - normalized
+    }
+
+    #[test]
+    fn test_self_reference_cross_folder() {
+        // entity_id = "projects-compass-v2", content refs [[Projects/compass-v2]]
+        // both normalize to "projects-compass-v2" → should be filtered
+        let content = "关于 [[Projects/compass-v2]] 的讨论";
+        let refs = ReferenceParser::extract_ids(content, Some("projects-compass-v2"));
+        assert!(refs.is_empty(), "cross-folder self-ref should be filtered");
     }
 }

--- a/compass-core/src/reference.rs
+++ b/compass-core/src/reference.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 static REF_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"\[\[([a-zA-Z0-9_-]+)\]\]"#).unwrap()
+    Regex::new(r#"\[\[([a-zA-Z0-9_/-]+)\]\]"#).unwrap()
 });
 
 /// Parser for [[id]] style references in markdown.


### PR DESCRIPTION
## Summary

**FileWatcher** — monitors vault directory, keeps Compass API in sync.

- Uses `watchdog` to recursively monitor vault *.md files
- 500ms coalescing event queue (debounces rapid file saves)
- Startup full-vault sync (catches changes while offline)
- Parses frontmatter via `python-frontmatter`
- Entity ID: `Inbox/note.md` → `inbox-note`
- API: `PUT /entities/{id}` (upsert) + `DELETE /entities/{id}` (cascade)

**Bug fix**: self-reference filter case-sensitivity — Rust extracts `Projects/compass-v2`, entity_id is `projects-compass-v2` → normalized before filter.

**API changes**:
- `PUT /entities/{entity_id}` — full entity update, recomputes score + refs atomically
- `DELETE /entities/{entity_id}` — cascade delete entity/scores/refs/events

**Config**: `.env` path now relative to `__file__` (was CWD-relative, broken when running from other dirs)

**Rust**: regex updated to `[a-zA-Z0-9_/-]+` to support cross-folder wiki-links

## Files changed

```
M  .gitignore
M  compass-api/pyproject.toml
M  compass-api/src/api/entities.py
M  compass-api/src/config.py
M  compass-core/src/reference.rs
A  compass-api/src/services/filewatcher.py
```