### PR TITLE
fix: replace print statements with logging (#27)

### DIFF
--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -1,5 +1,8 @@
 """Compass API — FastAPI entry point."""
+import logging
 from contextlib import asynccontextmanager
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 import uvicorn
 from fastapi import FastAPI
@@ -16,12 +19,12 @@ db = Database()
 async def lifespan(app: FastAPI):
     await db.connect()
     set_db(db)  # register the shared instance for Depends()
-    print(f"[Compass API] DB ready at {config.DB_PATH}")
-    print(f"[Compass API] Vault at {config.VAULT_PATH}")
-    print(f"[Compass API] Rust binary at {config.RUST_BINARY_PATH}")
+    logging.info(f"[Compass API] DB ready at {config.DB_PATH}")
+    logging.info(f"[Compass API] Vault at {config.VAULT_PATH}")
+    logging.info(f"[Compass API] Rust binary at {config.RUST_BINARY_PATH}")
     yield
     await db.close()
-    print("[Compass API] Shutdown complete")
+    logging.info("[Compass API] Shutdown complete")
 
 
 app = FastAPI(

--- a/compass-api/src/services/filewatcher.py
+++ b/compass-api/src/services/filewatcher.py
@@ -32,6 +32,9 @@ Frontmatter expected fields
 from __future__ import annotations
 
 import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
 import re
 import sys
 import threading
@@ -313,7 +316,7 @@ async def scan_vault() -> list[ParsedFile]:
     vault = config.VAULT_PATH
     results: list[ParsedFile] = []
     if not vault.exists():
-        print(f"[FileWatcher] Vault not found: {vault}")
+        logger.warning(f"[FileWatcher] Vault not found: {vault}")
         return results
     for path in vault.rglob("*.md"):
         vp = str(path.relative_to(vault))
@@ -331,13 +334,13 @@ async def scan_vault() -> list[ParsedFile]:
 async def full_sync() -> None:
     """Full vault scan: upsert every file. Used on startup."""
     files = await scan_vault()
-    print(f"[FileWatcher] Full sync: {len(files)} files found")
+    logger.info(f"[FileWatcher] Full sync: {len(files)} files found")
     for parsed in files:
         try:
             await api_upsert(parsed)
-            print(f"  [synced]   {parsed.vault_path} → {parsed.entity_id}")
+            logger.info(f"  [synced]   {parsed.vault_path} → {parsed.entity_id}")
         except Exception as exc:
-            print(f"  [error]    {parsed.vault_path}: {exc}")
+            logger.error(f"  [error]    {parsed.vault_path}: {exc}")
 
 
 # ---- main loop ----
@@ -350,26 +353,26 @@ async def process_events(queue: EventQueue) -> None:
         for vault_path, etype in events:
             entity_id = vault_path_to_entity_id(vault_path)
             if etype == "delete":
-                print(f"[FileWatcher] delete {vault_path}")
+                logger.info(f"[FileWatcher] delete {vault_path}")
                 try:
                     await api_delete(entity_id)
                 except Exception as exc:
-                    print(f"  [error] delete {entity_id}: {exc}")
+                    logger.error(f"  [error] delete {entity_id}: {exc}")
             else:
                 # create or update — re-parse the file and upsert
                 full_path = config.VAULT_PATH / vault_path
                 if not full_path.exists():
-                    print(f"[FileWatcher] skip (gone) {vault_path}")
+                    logger.info(f"[FileWatcher] skip (gone) {vault_path}")
                     continue
                 parsed = parse_markdown_file(full_path, vault_path)
                 if not parsed:
-                    print(f"[FileWatcher] skip (parse error) {vault_path}")
+                    logger.warning(f"[FileWatcher] skip (parse error) {vault_path}")
                     continue
-                print(f"[FileWatcher] {etype} {vault_path} → {entity_id}")
+                logger.info(f"[FileWatcher] {etype} {vault_path} → {entity_id}")
                 try:
                     await api_upsert(parsed)
                 except Exception as exc:
-                    print(f"  [error] upsert {entity_id}: {exc}")
+                    logger.error(f"  [error] upsert {entity_id}: {exc}")
 
 
 def run_watcher() -> None:
@@ -385,7 +388,7 @@ def run_watcher() -> None:
     observer = Observer()
     observer.schedule(handler, str(vault), recursive=True)
     observer.start()
-    print(f"[FileWatcher] Watching {vault} (recursive)")
+    logger.info(f"[FileWatcher] Watching {vault} (recursive)")
 
     # Run the async event processor in the event loop
     try:


### PR DESCRIPTION
## Summary

Replace all bare `print()` calls with proper `logging` module calls.

Fixes #27.

## Changes

**main.py:**
- Add `import logging` + `logging.basicConfig(level=logging.INFO, format="%(message)s")`
- Replace 4 startup/shutdown `print()` calls with `logging.info()`

**filewatcher.py:**
- Add `import logging` + `logger = logging.getLogger(__name__)`
- Replace 11 `print()` calls across `scan_vault()`, `full_sync()`, `process_events()`, and `run_watcher()` with appropriate `logger.info/warning/error`
