### PR TITLE
feat: Compass Skill usage guidelines for Agent (#18)

### DIFF
--- a/skills/compass/SKILL.md
+++ b/skills/compass/SKILL.md
@@ -1,7 +1,45 @@
 ---
 name: compass
 description: Access your personal knowledge graph — search, score, and navigate entities in your Compass PKM system. Use when user asks about notes, wants to find information, check scores, or manage knowledge.
----
+
+## When to Use Each Action
+
+| User Intent | Trigger Patterns | Action to Call | Response |
+|---|---|---|---|
+| **Quick capture** | Message starts with `/q`, or contains "记一下" / "存一下" / "帮我记" | `compass create` | Confirm with ID + title |
+| **Search knowledge** | Asks a knowledge question — "说说…" / "是什么…" / "介绍一下…" / "查一下…" | `compass search` | Formatted result list |
+| **Check score** | Message contains `/s` or asks "多少分" / "评分" | `compass get` | Entity detail + 3D scores |
+| **Daily feed** | Message is `/f` or "今天有什么" / "今日焦点" | `compass feed` | 3-section digest |
+| **Deep research** | Needs multiple related entities as context | `compass context` | Batch entities + suggestions |
+
+## Result Rendering Rules
+
+After calling a Compass action, format the raw JSON output into readable text — **never return raw JSON** to the user.
+
+```
+compass search → ## 搜索结果
+  1. [标题](ID) — score: X.X
+  2. ...
+
+compass feed → **今日焦点**
+  - [标题](ID) — ⭐X.X
+  **最近更新**
+  - ...
+  **战略焦点**
+  - ...
+
+compass get → **标题** (ID)
+  ⭐ 评分: interest X.X | strategy X.X | consensus X.X
+  📎 相关: [[链接列表]]
+```
+
+## Feishu Coordination
+
+- Compass result is self-contained → use `feishu.send_message` to deliver directly
+- Needs user confirmation before sending → return formatted text, let user decide
+- Uncertain or complex → return formatted text, do not auto-send
+- **Never** send raw JSON to Feishu
+
 
 # Compass — Personal Knowledge Graph Skill
 


### PR DESCRIPTION
## #18 修正版

### 问题
原题设错误：假设用户会用 `/q` `/r` 等机器前缀，或者让 Agent 理解前缀含义。

实际情况：飞书收到的是人话，Skill 自己要把人话翻译成正确的 compass API 调用。

### 修正后的方案
- **Skill 描述**：明确写「Handles natural language input, pass the user message as-is」
- **明确禁止**：不再要求用户使用命令前缀
- **触发条件表**：改为「用户说什么 → 调什么」
- **Action 描述**：全部改为接受自然语言，Skill 自己负责提取参数

### 具体改动
- `description`：强调处理自然语言输入
- `create`：从自然语言提取 title + content，category 默认 Inbox
- `search`：传入用户问题的自然语言描述
- `get`：先 search 找 ID 再 get
- `feed`：`/f` 或「今天有什么」触发
- `context`：传入研究问题的自然语言

### T4（E2E）— pending
需要 compass-api 运行 + 飞书打通后验证。

---
Closes #18