### PR TITLE
feat: Compass Skill render layer + two-step call pattern (#18)

### DIFF
--- a/skills/compass/SKILL.md
+++ b/skills/compass/SKILL.md
@@ -1,120 +1,102 @@
 ---
 name: compass
-description: Access your personal knowledge graph — search, score, and navigate entities in your Compass PKM system. Use when user asks about notes, wants to find information, check scores, or manage knowledge.
----
+description: Access your personal knowledge graph — search, score, and navigate entities in your Compass PKM system. Handles natural language input and translates API output to human-readable text.
 
-# Compass — Personal Knowledge Graph Skill
+## Two-Step Call Pattern
 
-Compass is your cognitive operating system. It indexes your Obsidian vault, maintains a scoring engine (interest × strategy × consensus with decay), and surfaces the most relevant knowledge at any moment.
+Every compass interaction follows this exact sequence:
 
-## Quick Reference
+1. **Call the action** → get raw JSON from the API
+2. **Call `compass render`** → translate JSON to human-readable text
+3. **Send via Feishu** → deliver the formatted text to the user
+
+**Never return raw JSON to the user. Never skip the render step.**
+
+## Intent Detection
+
+| User says... | Step 1 calls | Then calls render with... |
+|---|---|---|
+| "记一下..." / "存一下..." | `compass create` | `action=create` |
+| "说说..." / "是什么..." / "介绍一下..." | `compass search` | `action=search` |
+| "...多少分" / "...评分" | `compass get` | `action=get` |
+| "今天有什么" / "今日焦点" | `compass feed` | `action=feed` |
+| Deep research / needs context | `compass context` | `action=context` |
+| "Top 5" / ranking request | `compass top` | `action=top` |
+
+## compass-api Actions
 
 ```bash
 # Search entities
-compass search q=<query> [limit=20]
+compass search q=<natural language query> [limit=20]
 
-# Get top-scored entities
+# Top-scored entities
 compass top [limit=20] [category=]
 
-# Get single entity with refs
+# Single entity by ID
 compass get id=<entity_id>
 
-# Daily feed (top Inbox + recent + strategic)
+# Daily digest
 compass feed [limit=10]
 
-# Agent context preparation (returns scored entities for a task)
-compass context task=<task description> [top_k=5]
+# Agent context injection
+compass context task=<research question> [top_k=5]
 
-# Create a new entity
-compass create id=<id> title=<title> category=<category> vault_path=<path> [interest=5.0] [strategy=5.0] [consensus=0.0] [content=]
+# Create new entity
+compass create id=<id> title=<title> category=<category> vault_path=<path> [content=] [interest=5.0] [strategy=5.0] [consensus=0.0]
 
-# Update entity score
+# Update scores
 compass score id=<entity_id> [interest=<float>] [strategy=<float>] [consensus=<float>]
 ```
 
+## compass render — JSON to Human Text
+
+After any API call, pass the raw JSON output to `compass render`:
+
+```
+compass render raw=<JSON string> action=<action_name>
+```
+
+**Render output by action:**
+
+| action | Output format |
+|--------|--------------|
+| `search` | Numbered list: `1. [标题](id) — ⭐X.X分 [分类]` |
+| `top` | Numbered list: `1. [标题](id) — ⭐X.X分` |
+| `get` | Title block with scores and links |
+| `feed` | Three-section digest: **今日焦点** / **最近更新** / **战略焦点** |
+| `context` | Bulleted list with content snippets + reasoning |
+| `create` | `✅ 已创建：[标题](id)` |
+| `score` | `✅ 评分已更新：[标题](id) — ⭐X.X` |
+
+## Feishu Coordination
+
+- After `compass render` → use `feishu.send_message` to deliver
+- Needs user confirmation → return formatted text, let user decide
+- Uncertain → return formatted text, do not auto-send
+- **Never** send raw JSON to Feishu
+
 ## Core Concepts
 
-- **Entity**: A note/card in your Obsidian vault. Each has a unique `id` (normalized from vault path, e.g. `projects-compass-v2` from `Projects/compass-v2.md`)
-- **Scoring**: Three dimensions — `interest` (0-10, personal curiosity), `strategy` (0-10, strategic importance), `consensus` (0-10, peer validation). Final score decays over time with a 30-day half-life.
-- **References**: Entities can link to each other via `[[wiki-links]]`. Both outgoing and incoming refs are tracked.
-- **Feed**: Your daily digest — top Inbox items, recently updated high-scorers, and strategic (Direction category) items.
-
-## Action Details
-
-### search — Full-text search
-Search entities by keyword across title, category, and content.
-```
-compass search q=compass limit=10
-```
-Returns: `{"results": [...], "count": N}`
-
-### top — Top-scored entities
-Returns highest-scoring entities, optionally filtered by category.
-```
-compass top limit=5 category=Inbox
-compass top limit=10
-```
-Categories: `Inbox`, `Direction`, `Knowledge`, `Logs`, `Insights`
-
-### get — Single entity
-Get full entity data including outgoing and incoming references.
-```
-compass get id=projects-compass-v2
-```
-Returns: entity object with `outgoing_refs` and `incoming_refs` arrays.
-
-### feed — Daily digest
-Returns three sections: `top_inbox`, `recently_updated`, `strategic`.
-```
-compass feed limit=5
-```
-
-### context — Agent context injection
-For AI agent use — given a task/question, returns the most relevant scored entities to use as context.
-```
-compass context task="Explain the Compass scoring engine" top_k=5
-```
-Returns: `{"context": [...], "suggested_entities": [...], "reasoning": "..."}`
-
-### create — New entity
-Create a new vault entry. The `id` is the canonical entity ID (use lowercase, dashes for spaces/paths).
-```
-compass create id=my-quick-note title="Quick Note" category=Inbox vault_path=Inbox/quick-note.md content="Some initial content"
-```
-Vault path is relative to vault root (e.g. `Inbox/`, `Knowledge/`, `Direction/`).
-
-### score — Update scoring dimensions
-Update one or more scoring dimensions for an entity. Triggers score recomputation.
-```
-compass score id=projects-compass-v2 interest=8 strategy=6
-compass score id=projects-compass-v2 consensus=7
-```
+- **Entity**: A note in your Obsidian vault, identified by a unique `id` (lowercase, dashes)
+- **Scoring**: Three dimensions — `interest` (curiosity), `strategy` (importance), `consensus` (peer validation). Final score decays with a 30-day half-life
+- **References**: Entities link via `[[wiki-links]]`, tracked as outgoing and incoming
 
 ## Error Handling
 
-- **404 Not Found**: Entity does not exist. Check the `id` parameter.
-- **Connection refused**: compass-api is not running. Start it with `cd compass-api && .venv/bin/uvicorn src.main:app --reload`.
-- **Rate limit / server error**: Wait and retry with exponential backoff.
+- **404**: Entity not found — check the `id`
+- **Connection refused**: compass-api not running → start with `cd compass-api && .venv/bin/uvicorn src.main:app --reload`
+- **Rate limit**: wait and retry with exponential backoff
 
 ## Environment
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `COMPASS_API_URL` | `http://localhost:8080` | compass-api server address |
-
-Set `COMPASS_API_URL` if the API is running on a different host/port.
+| Variable | Default |
+|----------|---------|
+| `COMPASS_API_URL` | `http://localhost:8080` |
 
 ## compass-api Server
-
-The API must be running for this skill to work:
 
 ```bash
 cd /path/to/Compass/compass-api
 source .venv/bin/activate
 uvicorn src.main:app --reload --port 8080
-```
-
-For file watching (auto-sync vault changes):
-```bash
-python -m src.services.filewatcher
 ```

--- a/skills/compass/compass
+++ b/skills/compass/compass
@@ -167,6 +167,146 @@ def action_score(params: dict) -> None:
     print(json.dumps(result, indent=2))
 
 
+def _render_search(data: dict) -> str:
+    results = data.get("results", [])
+    if not results:
+        return "没有找到相关结果。"
+    lines = []
+    for i, ent in enumerate(results, 1):
+        score = ent.get("final_score", 0)
+        title = ent.get("title", ent.get("entity_id", "?"))
+        eid = ent.get("entity_id", "")
+        cat = ent.get("category", "")
+        lines.append(f"{i}. [{title}]({eid}) — ⭐{score:.1f}分  [{cat}]")
+    return "## 搜索结果\n" + "\n".join(lines)
+
+
+def _render_top(data: dict) -> str:
+    results = data.get("results", [])
+    if not results:
+        return "没有找到结果。"
+    lines = []
+    for i, ent in enumerate(results, 1):
+        score = ent.get("final_score", 0)
+        title = ent.get("title", ent.get("entity_id", "?"))
+        eid = ent.get("entity_id", "")
+        lines.append(f"{i}. [{title}]({eid}) — ⭐{score:.1f}分")
+    return "## Top " + str(len(results)) + "\n" + "\n".join(lines)
+
+
+def _render_get(data: dict) -> str:
+    title = data.get("title", "?")
+    eid = data.get("entity_id", "?")
+    cat = data.get("category", "?")
+    scores = data.get("scores", {})
+    interest = scores.get("interest", 0)
+    strategy = scores.get("strategy", 0)
+    consensus = scores.get("consensus", 0)
+    final = data.get("final_score", 0)
+
+    outgoing = data.get("outgoing_refs", [])
+    incoming = data.get("incoming_refs", [])
+
+    parts = [f"## {title} ({eid})", f"分类：{cat}", f"⭐ 评分：{final:.1f}（interest {interest:.1f} / strategy {strategy:.1f} / consensus {consensus:.1f}）"]
+
+    if outgoing:
+        refs = ", ".join(f"[[{r}]]" for r in outgoing)
+        parts.append(f"→ 引用：{refs}")
+    if incoming:
+        refs = ", ".join(f"[[{r}]]" for r in incoming)
+        parts.append(f"← 被引用：{refs}")
+
+    return "\n".join(parts)
+
+
+def _render_feed(data: dict) -> str:
+    lines = ["**今日焦点**"]
+    for ent in data.get("top_inbox", [])[:3]:
+        title = ent.get("title", "?")
+        eid = ent.get("entity_id", "?")
+        score = ent.get("final_score", 0)
+        lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
+
+    lines.append("**最近更新**")
+    for ent in data.get("recently_updated", [])[:3]:
+        title = ent.get("title", "?")
+        eid = ent.get("entity_id", "?")
+        score = ent.get("final_score", 0)
+        lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
+
+    lines.append("**战略焦点**")
+    for ent in data.get("strategic", [])[:3]:
+        title = ent.get("title", "?")
+        eid = ent.get("entity_id", "?")
+        score = ent.get("final_score", 0)
+        lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
+
+    return "\n".join(lines)
+
+
+def _render_context(data: dict) -> str:
+    ctx = data.get("context", [])
+    if not ctx:
+        return "没有找到相关上下文。"
+    lines = ["## 上下文"]
+    for ent in ctx:
+        title = ent.get("title", "?")
+        eid = ent.get("entity_id", "?")
+        summary = ent.get("content", "")[:100]
+        score = ent.get("final_score", 0)
+        lines.append(f"- [{title}]({eid})：{summary}... ⭐{score:.1f}")
+    reasoning = data.get("reasoning", "")
+    if reasoning:
+        lines.append(f"\n推理：{reasoning}")
+    return "\n".join(lines)
+
+
+def _render_create(data: dict) -> str:
+    title = data.get("title", "?")
+    eid = data.get("entity_id", "?")
+    return f"✅ 已创建：[{title}]({eid})"
+
+
+def _render_score(data: dict) -> str:
+    title = data.get("title", "?")
+    eid = data.get("entity_id", "?")
+    score = data.get("final_score", 0)
+    return f"✅ 评分已更新：[{title}]({eid}) — ⭐{score:.1f}"
+
+
+def action_render(params: dict) -> None:
+    raw = params.get("raw")
+    action_name = params.get("action")
+    if not raw:
+        print(json.dumps({"error": "raw is required"}), file=sys.stderr)
+        sys.exit(1)
+    if not action_name:
+        print(json.dumps({"error": "action is required"}), file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"error": f"invalid JSON: {e}"}), file=sys.stderr)
+        sys.exit(1)
+
+    renderers = {
+        "search": _render_search,
+        "top": _render_top,
+        "get": _render_get,
+        "feed": _render_feed,
+        "context": _render_context,
+        "create": _render_create,
+        "score": _render_score,
+    }
+
+    if action_name not in renderers:
+        print(json.dumps({"error": f"unknown action: {action_name}", "available": list(renderers.keys())}), file=sys.stderr)
+        sys.exit(1)
+
+    print(renderers[action_name](data))
+
+
 # ---- Dispatch ----
 
 
@@ -178,6 +318,7 @@ ACTIONS = {
     "context": action_context,
     "create": action_create,
     "score": action_score,
+    "render": action_render,
 }
 
 


### PR DESCRIPTION
## #18 — Compass Skill 与 OpenClaw Agent 配合调优

### 核心设计：两层架构
- **执行层**：7 个 compass action（search/top/get/feed/context/create/score）返回原始 JSON
- **翻译层**：新增 `compass render` action，将 JSON 翻译为人类可读文本

### 执行流程
```
飞书 → Agent → compass <action> → compass-api(JSON) → compass render → 人话 → Feishu → 真人
```

### T1 — render action（代码）
- 新增 `action_render()` + 7 个 render 函数
- `render(raw=<JSON>, action=<action名>)`
- 每个 action 对应专属格式（见 SKILL.md 格式表）

### T2 — SKILL.md 配置
- 两步调用模式（call → render → 发飞书）
- 自然语言意图检测表
- 各 action 输出格式说明

### T3 — Feishu 配合规则

### T4 — E2E 验证（pending）
需要 compass-api 运行 + 飞书连通后测试。

---
Closes #18