### PR TITLE
fix: FTS5 delete trigger syntax + Annotated Depends pattern (#38)

### DIFF
--- a/compass-api/src/api/agent.py
+++ b/compass-api/src/api/agent.py
@@ -25,7 +25,7 @@ class ContextResponse(BaseModel):
 
 
 @router.post("/context", response_model=ContextResponse)
-async def get_context(req: ContextRequest, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> ContextResponse:
+async def get_context(req: ContextRequest, db: Annotated[Database, Depends(get_db)] = None) -> ContextResponse:
     """Search and score entities as context for an agent task."""
     candidates = await db.search_entities(req.task, limit=req.top_k * 2)
     if not candidates:

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -107,7 +107,7 @@ class EntityResponse(BaseModel):
 
 
 @router.post("", response_model=EntityResponse)
-async def create_entity(entity: EntityCreate, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> EntityResponse:
+async def create_entity(entity: EntityCreate, db: Annotated[Database, Depends(get_db)] = None) -> EntityResponse:
     """Create a new entity with computed score and extracted refs."""
     now = datetime.now(tz=timezone.utc).isoformat()
     vault_path = entity.vault_path
@@ -150,7 +150,7 @@ async def create_entity(entity: EntityCreate, db: Annotated[Database, Depends(ge
 
 
 @router.get("/search")
-async def search_entities(q: str, limit: int = 20, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> dict:
+async def search_entities(q: str, limit: int = 20, db: Annotated[Database, Depends(get_db)] = None) -> dict:
     """Full-text search across entity titles and categories via FTS5."""
     results = await db.search_entities(q, limit=limit)
     return {"results": results, "count": len(results)}
@@ -158,7 +158,7 @@ async def search_entities(q: str, limit: int = 20, db: Annotated[Database, Depen
 
 @router.get("/top")
 async def top_entities(
-    limit: int = 20, category: Optional[str] = None, db: Annotated[Database, Depends(get_db)] = Depends(get_db)
+    limit: int = 20, category: Optional[str] = None, db: Annotated[Database, Depends(get_db)] = None
 ) -> dict:
     """Return top-scoring entities, optionally filtered by category."""
     results = await db.get_top_entities(limit=limit, category=category)
@@ -169,7 +169,7 @@ async def top_entities(
 async def update_entity(
     entity_id: str,
     update: EntityCreate,
-    db: Annotated[Database, Depends(get_db)] = Depends(get_db)
+    db: Annotated[Database, Depends(get_db)] = None
 ) -> EntityResponse:
     """Full update: re-parses content for refs, recomputes scores.
 
@@ -237,7 +237,7 @@ async def update_entity(
 
 
 @router.delete("/{entity_id}")
-async def delete_entity(entity_id: str, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> dict:
+async def delete_entity(entity_id: str, db: Annotated[Database, Depends(get_db)] = None) -> dict:
     """Delete entity and all associated data (scores, refs, events).
 
     Used by FileWatcher when a vault file is removed.
@@ -261,7 +261,7 @@ async def delete_entity(entity_id: str, db: Annotated[Database, Depends(get_db)]
 
 
 @router.get("/{entity_id}")
-async def get_entity(entity_id: str, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> dict:
+async def get_entity(entity_id: str, db: Annotated[Database, Depends(get_db)] = None) -> dict:
     """Fetch a single entity by ID with its incoming and outgoing references."""
     entity = await db.get_entity(entity_id)
     if not entity:

--- a/compass-api/src/api/feed.py
+++ b/compass-api/src/api/feed.py
@@ -17,7 +17,7 @@ class FeedResponse(BaseModel):
 
 
 @router.get("/today", response_model=FeedResponse)
-async def daily_feed(limit: int = 10, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> FeedResponse:
+async def daily_feed(limit: int = 10, db: Annotated[Database, Depends(get_db)] = None) -> FeedResponse:
     """Return the daily digest: top Inbox items, recently updated, and strategic items."""
     top_inbox = await db.get_top_entities(limit=limit, category="Inbox")
     recently = await db.get_top_entities(limit=limit)

--- a/compass-api/src/api/scores.py
+++ b/compass-api/src/api/scores.py
@@ -31,7 +31,7 @@ class ScoreResponse(BaseModel):
 
 
 @router.post("/update", response_model=ScoreResponse)
-async def update_score(update: ScoreUpdate, db: Annotated[Database, Depends(get_db)] = Depends(get_db)) -> ScoreResponse:
+async def update_score(update: ScoreUpdate, db: Annotated[Database, Depends(get_db)] = None) -> ScoreResponse:
     """Recompute and persist an entity's score from updated interest/strategy/consensus values."""
     entity = await db.get_entity(update.entity_id)
     if not entity:

--- a/compass-api/src/db/schema.sql
+++ b/compass-api/src/db/schema.sql
@@ -22,14 +22,14 @@ CREATE TABLE IF NOT EXISTS entities (
 CREATE TABLE IF NOT EXISTS scores (
     entity_id                   TEXT PRIMARY KEY REFERENCES entities(id),
     interest                     REAL DEFAULT 5.0,
-    strategy                      REAL DEFAULT 5.0,
-    consensus                     REAL DEFAULT 0.0,
+    strategy                     REAL DEFAULT 5.0,
+    consensus                    REAL DEFAULT 0.0,
     final_score                  REAL DEFAULT 0.0,
-    interest_half_life_days       REAL DEFAULT 30.0,
-    strategy_half_life_days       REAL DEFAULT 365.0,
-    consensus_half_life_days      REAL DEFAULT 60.0,
-    manual_override               INTEGER DEFAULT 0,
-    updated_at                    TEXT NOT NULL
+    interest_half_life_days      REAL DEFAULT 30.0,
+    strategy_half_life_days      REAL DEFAULT 365.0,
+    consensus_half_life_days     REAL DEFAULT 60.0,
+    manual_override              INTEGER DEFAULT 0,
+    updated_at                   TEXT NOT NULL
 );
 
 -- Bidirectional references
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS timeline_events (
     created_at  TEXT NOT NULL
 );
 
--- FTS5 full-text search (plain — triggers handle sync manually)
+-- FTS5 full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
     id,
     title,
@@ -66,7 +66,8 @@ CREATE INDEX IF NOT EXISTS idx_references_source ON "references"(source_id);
 CREATE INDEX IF NOT EXISTS idx_references_target ON "references"(target_id);
 CREATE INDEX IF NOT EXISTS idx_timeline_entity ON timeline_events(entity_id);
 
--- FTS5 sync triggers (keep full-text index consistent with entities table)
+-- FTS5 sync triggers
+-- NOTE: FTS5 plain tables support DELETE statements directly
 CREATE TRIGGER IF NOT EXISTS entities_fts_insert
 AFTER INSERT ON entities BEGIN
     INSERT INTO entities_fts(id, title, category)
@@ -75,14 +76,12 @@ END;
 
 CREATE TRIGGER IF NOT EXISTS entities_fts_delete
 AFTER DELETE ON entities BEGIN
-    INSERT INTO entities_fts(entities_fts, id, title, category)
-    VALUES ('delete', old.id, old.title, old.category);
+    DELETE FROM entities_fts WHERE id = old.id;
 END;
 
 CREATE TRIGGER IF NOT EXISTS entities_fts_update
 AFTER UPDATE ON entities BEGIN
-    INSERT INTO entities_fts(entities_fts, id, title, category)
-    VALUES ('delete', old.id, old.title, old.category);
+    DELETE FROM entities_fts WHERE id = old.id;
     INSERT INTO entities_fts(id, title, category)
     VALUES (new.id, new.title, new.category);
 END;

--- a/compass-api/tests/integration/test_fts_triggers.py
+++ b/compass-api/tests/integration/test_fts_triggers.py
@@ -1,0 +1,188 @@
+"""Integration tests for FTS5 sync triggers (INSERT / DELETE / UPDATE on entities).
+
+These tests directly validate the trigger fix in PR #39:
+- OLD: INSERT INTO entities_fts(entities_fts, ...) VALUES('delete', ...) — invalid syntax
+- NEW: DELETE FROM entities_fts WHERE id = old.id — direct DELETE supported by FTS5 plain tables
+
+All three triggers (insert / delete / update) are exercised to confirm FTS index
+stays in sync after each operation.
+"""
+import pytest
+import pytest_asyncio
+from pathlib import Path
+
+from src.db.database import Database, init_db
+
+
+async def _make_db(tmp_path: Path) -> Database:
+    """Helper: create a fresh temp DB for each test."""
+    db_path = tmp_path / "test_fts.db"
+    conn = await init_db(db_path)
+    database = Database(db_path)
+    database._conn = conn
+    return database
+
+
+def _entity(entity_id: str, title: str, category: str = "Inbox") -> dict:
+    now = "2026-04-14T00:00:00+00:00"
+    return {
+        "id": entity_id,
+        "file_path": f"/vault/{entity_id}.md",
+        "vault_path": f"{entity_id}.md",
+        "title": title,
+        "category": category,
+        "created_at": now,
+        "updated_at": now,
+        "last_boosted_at": now,
+        "metadata": {},
+    }
+
+
+def _score(entity_id: str) -> dict:
+    now = "2026-04-14T00:00:00+00:00"
+    return {
+        "entity_id": entity_id,
+        "interest": 5.0,
+        "strategy": 5.0,
+        "consensus": 0.0,
+        "final_score": 5.0,
+        "updated_at": now,
+    }
+
+
+async def _fts_search(database: Database, query: str) -> list[dict]:
+    """Raw FTS5 search directly against entities_fts, bypassing the API layer."""
+    cur = await database.conn.execute(
+        f"SELECT id FROM entities_fts WHERE entities_fts MATCH '{query}' ORDER BY rank"
+    )
+    rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_fts_insert_trigger(tmp_path):
+    """INSERT trigger: new entity should be immediately searchable via FTS5."""
+    db = await _make_db(tmp_path)
+    try:
+        await db.create_entity_full(
+            _entity("compass-v2", "Compass Version Two"),
+            _score("compass-v2"),
+            ref_ids=[],
+        )
+
+        results = await _fts_search(db, "Compass")
+        ids = [r["id"] for r in results]
+        assert "compass-v2" in ids, "Entity must appear in FTS after INSERT"
+    finally:
+        await db.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fts_delete_trigger(tmp_path):
+    """DELETE trigger: deleted entity should no longer be searchable via FTS5.
+
+    This is the core fix: the old 'INSERT INTO fts(fts, ...) VALUES(delete, ...)'
+    syntax was invalid. The new 'DELETE FROM entities_fts WHERE id = old.id' is
+    the correct FTS5 plain-table deletion approach.
+    """
+    db = await _make_db(tmp_path)
+    try:
+        await db.create_entity_full(
+            _entity("to-delete", "Entity To Delete"),
+            _score("to-delete"),
+            ref_ids=[],
+        )
+
+        # Confirm it's indexed
+        before = await _fts_search(db, "Delete")
+        assert any(r["id"] == "to-delete" for r in before), "Entity must be indexed before DELETE"
+
+        # Delete via raw SQL (mirrors what delete_entity endpoint does:
+        # must remove FK-referencing rows first before deleting the entity)
+        await db.begin()
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ? OR target_id = ?', ("to-delete", "to-delete"))
+        await db.conn.execute("DELETE FROM timeline_events WHERE entity_id = ?", ("to-delete",))
+        await db.conn.execute("DELETE FROM scores WHERE entity_id = ?", ("to-delete",))
+        await db.conn.execute("DELETE FROM entities WHERE id = ?", ("to-delete",))
+        await db.commit()
+
+        # FTS index must be updated by the trigger
+        after = await _fts_search(db, "Delete")
+        assert not any(r["id"] == "to-delete" for r in after), \
+            "Entity must NOT appear in FTS after DELETE — trigger fix required"
+    finally:
+        await db.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fts_update_trigger(tmp_path):
+    """UPDATE trigger: entity title change should be reflected in FTS5 index."""
+    db = await _make_db(tmp_path)
+    try:
+        await db.create_entity_full(
+            _entity("update-me", "Old Title Keyword"),
+            _score("update-me"),
+            ref_ids=[],
+        )
+
+        # Confirm old title is indexed
+        before = await _fts_search(db, "OldTitle")
+        # Note: FTS5 tokenises on whitespace; search for one unique word
+        before_all = await _fts_search(db, "Keyword")
+        assert any(r["id"] == "update-me" for r in before_all), "Old title must be indexed"
+
+        # Update the entity title
+        now = "2026-04-14T01:00:00+00:00"
+        await db.begin()
+        await db.conn.execute(
+            "UPDATE entities SET title = ?, updated_at = ? WHERE id = ?",
+            ("New Title Revised", now, "update-me"),
+        )
+        await db.commit()
+
+        # Old keyword should be gone; new keyword should appear
+        old_results = await _fts_search(db, "Keyword")
+        new_results = await _fts_search(db, "Revised")
+        assert not any(r["id"] == "update-me" for r in old_results), \
+            "Old title keyword must NOT be in FTS after UPDATE"
+        assert any(r["id"] == "update-me" for r in new_results), \
+            "New title keyword must appear in FTS after UPDATE"
+    finally:
+        await db.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fts_multiple_entities_isolation(tmp_path):
+    """Deleting one entity must not remove other entities from the FTS index."""
+    db = await _make_db(tmp_path)
+    try:
+        await db.create_entity_full(
+            _entity("keep-me", "Keeper Entity Alpha"),
+            _score("keep-me"),
+            ref_ids=[],
+        )
+        await db.create_entity_full(
+            _entity("remove-me", "Removable Entity Beta"),
+            _score("remove-me"),
+            ref_ids=[],
+        )
+
+        # Delete only the second entity (FK order: refs → events → scores → entity)
+        await db.begin()
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ? OR target_id = ?', ("remove-me", "remove-me"))
+        await db.conn.execute("DELETE FROM timeline_events WHERE entity_id = ?", ("remove-me",))
+        await db.conn.execute("DELETE FROM scores WHERE entity_id = ?", ("remove-me",))
+        await db.conn.execute("DELETE FROM entities WHERE id = ?", ("remove-me",))
+        await db.commit()
+
+        # "keep-me" must still be searchable
+        results = await _fts_search(db, "Keeper")
+        assert any(r["id"] == "keep-me" for r in results), \
+            "Sibling entity must remain in FTS after another entity is deleted"
+
+        # "remove-me" must be gone
+        removed = await _fts_search(db, "Removable")
+        assert not any(r["id"] == "remove-me" for r in removed), \
+            "Deleted entity must not appear in FTS"
+    finally:
+        await db.conn.close()


### PR DESCRIPTION
## Fixes #38

### Bug 1: FTS5 triggers using invalid syntax

**Problem:** The FTS5 UPDATE/DELETE triggers used `INSERT INTO fts(fts, id, ...) VALUES(delete, ...)` but `fts` is not a column in the FTS5 virtual table. This caused `UPDATE entities` to always fail with `sqlite3.OperationalError: SQL logic error`.

**Root cause:** FTS5 plain tables (without content=) support `DELETE FROM fts WHERE ...` syntax directly.

**Fix:** Replace the invalid insert-with-delete-command with standard DELETE:
```sql
-- OLD (broken):
INSERT INTO entities_fts(entities_fts, id, title, category)
  VALUES (delete, old.id, old.title, old.category);

-- NEW (works):
DELETE FROM entities_fts WHERE id = old.id;
```

### Bug 2: Annotated + Depends default conflict

**Problem:** PR #32 added `Annotated[Database, Depends(get_db)] = Depends(get_db)` pattern. FastAPI rejects this: `Cannot specify Depends in Annotated AND default value together`.

**Fix:** Remove the `= Depends(get_db)` default, keep only `= None`:
```python
# OLD (broken):
async def create_entity(..., db: Annotated[Database, Depends(get_db)] = Depends(get_db))

# NEW (works):  
async def create_entity(..., db: Annotated[Database, Depends(get_db)] = None)
```

FastAPI ignores the `= None` default when Depends() is present in Annotated.