### PR TITLE
fix: add GET /entities list-all endpoint + ignore vault/uv.lock (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ data/
 *.db-shm
 *.db-wal
 .env
+
+# Local vault (user-specific knowledge base content)
+vault/
+uv.lock

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timezone
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel, Field
 
 from src import config
@@ -167,8 +167,8 @@ async def top_entities(
 
 @router.get("")
 async def list_entities(
-    limit: int = 100,
-    offset: int = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
     category: Optional[str] = None,
     db: Annotated[Database, Depends(get_db)] = None,
 ) -> dict:

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -165,6 +165,18 @@ async def top_entities(
     return {"results": results, "count": len(results)}
 
 
+@router.get("")
+async def list_entities(
+    limit: int = 100,
+    offset: int = 0,
+    category: Optional[str] = None,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> dict:
+    """List all entities without requiring a query, supports pagination and category filter."""
+    results = await db.get_all_entities(limit=limit, offset=offset, category=category)
+    return {"results": results, "count": len(results)}
+
+
 @router.put("/{entity_id}", response_model=EntityResponse)
 async def update_entity(
     entity_id: str,

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -252,6 +252,25 @@ class Database:
             row = await cur.fetchone()
         return dict(row) if row else None
 
+    async def get_all_entities(
+        self, limit: int = 100, offset: int = 0, category: Optional[str] = None
+    ) -> list[dict[str, Any]]:
+        """List all entities with optional pagination and category filter."""
+        q = """
+            SELECT e.*, s.final_score
+            FROM entities e
+            LEFT JOIN scores s ON s.entity_id = e.id
+        """
+        params: list[Any] = []
+        if category:
+            q += " WHERE e.category = ?"
+            params.append(category)
+        q += " ORDER BY e.updated_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        cur = await self.conn.execute(q, params)
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
     async def search_entities(
         self, query: str, limit: int = 20
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Add `GET /entities` endpoint without required query parameter, supporting pagination and category filtering. Also add `vault/` and `uv.lock` to `.gitignore`.

## Changes

- `Database.get_all_entities(limit, offset, category)` — new method
- `GET /entities` — list all entities, supports limit, offset, category query params
- Add `vault/` and `uv.lock` to `.gitignore` (prevent local paths from leaking into repo)

## Test plan

- [x] GET /entities returns entity list
- [x] GET /entities?limit=10&offset=0 pagination works
- [x] GET /entities?category=Inbox category filtering works
- [ ] 25 existing tests still pass

Closes #44