### PR TITLE
feat(p2): GET /graph/neighbors/{id} basic neighbor query (#51)

### DIFF
--- a/compass-api/src/api/graph.py
+++ b/compass-api/src/api/graph.py
@@ -1,0 +1,111 @@
+"""REST endpoint: graph neighbor queries."""
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+from src.db.database import Database, get_db
+
+router = APIRouter(prefix="/graph", tags=["graph"])
+
+
+class GraphNode(BaseModel):
+    id: str
+    title: str
+    entity_type: str
+    score_composite: Optional[float] = None
+
+
+class GraphEdge(BaseModel):
+    source: str
+    target: str
+    ref_type: str  # always "cites" for now
+    strength: float
+    direction: str  # "incoming" | "outgoing"
+
+
+class NeighborsResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    total_neighbors: int
+
+
+@router.get("/neighbors/{entity_id}", response_model=NeighborsResponse)
+async def get_neighbors(
+    entity_id: str,
+    db: Database = Depends(get_db),
+) -> NeighborsResponse:
+    """Return all direct neighbors (incoming + outgoing) of an entity."""
+    # Verify entity exists
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    # OUTGOING: references where source_id = entity_id
+    out_cur = await db.conn.execute(
+        """
+        SELECT r.target_id, r.strength, e.title, e.entity_type, s.final_score
+        FROM "references" r
+        JOIN entities e ON e.id = r.target_id
+        LEFT JOIN scores s ON s.entity_id = r.target_id
+        WHERE r.source_id = ?
+        """,
+        (entity_id,),
+    )
+    out_rows = await out_cur.fetchall()
+
+    # INCOMING: references where target_id = entity_id
+    in_cur = await db.conn.execute(
+        """
+        SELECT r.source_id, r.strength, e.title, e.entity_type, s.final_score
+        FROM "references" r
+        JOIN entities e ON e.id = r.source_id
+        LEFT JOIN scores s ON s.entity_id = r.source_id
+        WHERE r.target_id = ?
+        """,
+        (entity_id,),
+    )
+    in_rows = await in_cur.fetchall()
+
+    # Deduplicate nodes
+    nodes_map: dict[str, GraphNode] = {}
+    edges: list[GraphEdge] = []
+
+    for row in out_rows:
+        tid = row["target_id"]
+        if tid not in nodes_map:
+            nodes_map[tid] = GraphNode(
+                id=tid,
+                title=row["title"],
+                entity_type=row["entity_type"],
+                score_composite=row["final_score"],
+            )
+        edges.append(GraphEdge(
+            source=entity_id,
+            target=tid,
+            ref_type="cites",  # all refs currently are cites
+            strength=row["strength"],
+            direction="outgoing",
+        ))
+
+    for row in in_rows:
+        sid = row["source_id"]
+        if sid not in nodes_map:
+            nodes_map[sid] = GraphNode(
+                id=sid,
+                title=row["title"],
+                entity_type=row["entity_type"],
+                score_composite=row["final_score"],
+            )
+        edges.append(GraphEdge(
+            source=sid,
+            target=entity_id,
+            ref_type="cites",
+            strength=row["strength"],
+            direction="incoming",
+        ))
+
+    return NeighborsResponse(
+        nodes=list(nodes_map.values()),
+        edges=edges,
+        total_neighbors=len(nodes_map),
+    )

--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src import config
 from src.db.database import Database, set_db
-from src.api import entities, scores, feed, agent
+from src.api import entities, scores, feed, agent, graph
 
 # Global DB — initialized once at startup
 db = Database()
@@ -39,6 +39,7 @@ app.include_router(entities.router)
 app.include_router(scores.router)
 app.include_router(feed.router)
 app.include_router(agent.router)
+app.include_router(graph.router)
 
 
 @app.get("/health")

--- a/compass-api/tests/api/test_graph.py
+++ b/compass-api/tests/api/test_graph.py
@@ -1,0 +1,86 @@
+"""Tests for /graph endpoints."""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.conftest import *  # imports db, mock_db, client fixtures
+
+
+class TestNeighbors:
+    """Test GET /graph/neighbors/{entity_id}"""
+
+    def test_404_for_nonexistent(self, client):
+        """Non-existent entity returns 404."""
+        resp = client.get("/graph/neighbors/nonexistent-id")
+        assert resp.status_code == 404
+
+    def test_empty_returns_empty_lists(self, mock_db):
+        """Entity with no refs returns empty nodes/edges arrays."""
+        from src.db.database import Database, set_db
+
+        db = Database()
+        # Reconnect to the temp db used by the test
+        from tests.conftest import _DB_PATH
+        from pathlib import Path
+        db._conn = mock_db._conn  # reuse the existing connection
+        set_db(db)
+
+        entity_id = "know-lone-001"
+        now = "2026-05-05T00:00:00Z"
+        mock_db.conn.execute(
+            'INSERT INTO entities (id, title, entity_type, category, file_path, vault_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            (entity_id, "Lone Entity", "knowledge", "Inbox", "/vault/Inbox/lone.md", "Inbox/lone.md", now, now),
+        )
+        mock_db.conn.execute(
+            'INSERT INTO scores (entity_id, interest, strategy, consensus, final_score, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            (entity_id, 5.0, 5.0, 0.0, 5.0, now),
+        )
+        mock_db.commit()
+
+        # Use the mock_db's connection via client fixture which has app context
+        with patch("src.core.rust_client.rust_client") as mock_rust:
+            mock_rust.compute_score = AsyncMock(return_value=MagicMock(
+                final_score=5.0, decay_factor=0.95, days_elapsed=1.0,
+            ))
+            mock_rust.parse_refs = AsyncMock(return_value=MagicMock(refs=[]))
+            from src.main import app
+            with TestClient(app) as tc:
+                resp = tc.get(f"/graph/neighbors/{entity_id}")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["nodes"] == []
+                assert data["edges"] == []
+                assert data["total_neighbors"] == 0
+
+    def test_response_schema_shape(self, mock_db):
+        """Response contains expected keys and types."""
+        from src.db.database import Database, set_db
+
+        entity_id = "know-schema-001"
+        now = "2026-05-05T00:00:00Z"
+        mock_db.conn.execute(
+            'INSERT INTO entities (id, title, entity_type, category, file_path, vault_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            (entity_id, "Schema Test", "knowledge", "Inbox", "/vault/Inbox/schema.md", "Inbox/schema.md", now, now),
+        )
+        mock_db.conn.execute(
+            'INSERT INTO scores (entity_id, interest, strategy, consensus, final_score, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            (entity_id, 5.0, 5.0, 0.0, 5.0, now),
+        )
+        mock_db.commit()
+
+        with patch("src.core.rust_client.rust_client") as mock_rust:
+            mock_rust.compute_score = AsyncMock(return_value=MagicMock(
+                final_score=5.0, decay_factor=0.95, days_elapsed=1.0,
+            ))
+            mock_rust.parse_refs = AsyncMock(return_value=MagicMock(refs=[]))
+            from src.main import app
+            with TestClient(app) as tc:
+                resp = tc.get(f"/graph/neighbors/{entity_id}")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert "nodes" in data
+                assert "edges" in data
+                assert "total_neighbors" in data
+                assert isinstance(data["nodes"], list)
+                assert isinstance(data["edges"], list)
+                assert isinstance(data["total_neighbors"], int)


### PR DESCRIPTION
## Summary

Implement `GET /graph/neighbors/{id}` — basic neighbor query for Compass Phase 2.

### What
- New `/graph/neighbors/{entity_id}` endpoint returning all direct neighbors (incoming + outgoing)
- Nodes include id, title, entity_type, score_composite
- Edges include source, target, ref_type, strength, direction
- 404 for non-existent entities, empty arrays for entities with no refs

### Changes
- `compass-api/src/api/graph.py` — new router with `NeighborsResponse` model
- `compass-api/src/main.py` — registered `graph.router`
- `compass-api/tests/api/test_graph.py` — basic test coverage

Closes #51