### PR TITLE
feat(p2): Insight-1 CRUD + Timeline-2 (#63, #60)

### DIFF
--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -1,5 +1,5 @@
 """REST endpoints for entity management."""
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, HTTPException, Depends, Query
@@ -482,3 +482,117 @@ async def record_access(
         accessed_at=now_str,
         decay_updated=True,
     )
+
+
+# ---- Timeline-2: GET /entities/timeline ----
+
+class TimelineItem(BaseModel):
+    entity_id: str
+    title: str
+    category: str
+    event_type: str
+    event_trigger: Optional[str]
+    created_at: str
+
+
+class TimelineResponse(BaseModel):
+    items: list[TimelineItem]
+    total: int
+    has_more: bool
+
+
+@router.get("/timeline", response_model=TimelineResponse)
+async def get_entities_timeline(
+    start: Annotated[str, Query(description="ISO datetime start of time window")],
+    end: Annotated[
+        Optional[str],
+        Query(description="ISO datetime end of time window (defaults to now)"),
+    ] = None,
+    event_type: Annotated[
+        Optional[str],
+        Query(description="Filter by event type"),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> TimelineResponse:
+    """Return entities with timeline events in a time range.
+
+    Shows the most recent event per entity within the window.
+    """
+    # Parse datetimes
+    try:
+        start_dt = datetime.fromisoformat(start.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid start datetime format")
+
+    if end:
+        try:
+            end_dt = datetime.fromisoformat(end.replace("Z", "+00:00"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid end datetime format")
+    else:
+        end_dt = datetime.now(tz=timezone.utc)
+
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="end must be after start")
+
+    # Build query — latest event per entity
+    params: list[Any] = [start_dt.isoformat(), end_dt.isoformat()]
+
+    event_filter = ""
+    if event_type:
+        event_filter = " AND te.event_type = ?"
+        params.append(event_type)
+
+    # Count total unique entities with matching events
+    count_sql = f"""
+        SELECT COUNT(DISTINCT te.entity_id)
+        FROM timeline_events te
+        JOIN entities e ON e.id = te.entity_id
+        WHERE te.created_at >= ? AND te.created_at <= ?{event_filter}
+    """
+    async with db.conn.execute(count_sql, params) as cur:
+        total = (await cur.fetchone())[0]
+
+    # Paginated items — latest event per entity
+    paginated_sql = f"""
+        WITH ranked AS (
+            SELECT
+                te.entity_id,
+                te.event_type,
+                te.trigger,
+                te.created_at,
+                e.title,
+                e.category,
+                ROW_NUMBER() OVER (
+                    PARTITION BY te.entity_id
+                    ORDER BY te.created_at DESC
+                ) AS rn
+            FROM timeline_events te
+            JOIN entities e ON e.id = te.entity_id
+            WHERE te.created_at >= ? AND te.created_at <= ?{event_filter}
+        )
+        SELECT entity_id, title, category, event_type, trigger, created_at
+        FROM ranked
+        WHERE rn = 1
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+    """
+    params.extend([limit, offset])
+    async with db.conn.execute(paginated_sql, params) as cur:
+        rows = await cur.fetchall()
+
+    items = [
+        TimelineItem(
+            entity_id=row["entity_id"],
+            title=row["title"],
+            category=row["category"],
+            event_type=row["event_type"],
+            event_trigger=row["trigger"],
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+    has_more = (offset + limit) < total
+    return TimelineResponse(items=items, total=total, has_more=has_more)

--- a/compass-api/src/api/graph.py
+++ b/compass-api/src/api/graph.py
@@ -1,7 +1,8 @@
 """REST endpoint: graph neighbor queries."""
+from typing import Annotated, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import Optional
 
 from src.db.database import Database, get_db
 

--- a/compass-api/src/api/insights.py
+++ b/compass-api/src/api/insights.py
@@ -1,0 +1,182 @@
+"""REST endpoints for Insight management."""
+from datetime import datetime, timezone
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, HTTPException, Depends, Query
+from pydantic import BaseModel, Field
+
+from src.db.database import Database, get_db
+
+router = APIRouter(prefix="/insights", tags=["insights"])
+
+
+# ---- Request/Response schemas ----
+
+class InsightCreate(BaseModel):
+    """Schema for creating a new insight via POST /insights."""
+
+    entity_id: str
+    title: str
+    content: Optional[str] = None
+
+
+class InsightResponse(BaseModel):
+    """Schema returned after creating or fetching an insight."""
+
+    id: str
+    entity_id: str
+    title: str
+    content: Optional[str]
+    maturity: str
+    source_type: str
+    created_at: str
+    updated_at: str
+
+
+class InsightListItem(BaseModel):
+    """Single item in GET /insights response."""
+
+    id: str
+    entity_id: str
+    title: str
+    maturity: str
+    source_type: str
+    created_at: str
+    updated_at: str
+
+
+class InsightListResponse(BaseModel):
+    """Response schema for GET /insights."""
+
+    items: list[InsightListItem]
+    total: int
+    has_more: bool
+
+
+# ---- Maturity state machine ----
+
+VALID_MATURITY_TRANSITIONS = {
+    "seedling": ["sprout"],
+    "sprout": ["mature"],
+    "mature": [],
+}
+
+
+def _next_maturity(current: str) -> Optional[str]:
+    """Return the next maturity level, or None if fully mature."""
+    transitions = VALID_MATURITY_TRANSITIONS.get(current, [])
+    return transitions[0] if transitions else None
+
+
+# ---- Endpoints ----
+
+@router.post("", response_model=InsightResponse)
+async def create_insight(
+    insight: InsightCreate,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> InsightResponse:
+    """Create a new insight attached to an entity."""
+    entity = await db.get_entity(insight.entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    insight_id = f"insight-{insight.entity_id}-{now[:10]}"
+
+    data = {
+        "id": insight_id,
+        "entity_id": insight.entity_id,
+        "title": insight.title,
+        "content": insight.content,
+        "maturity": "seedling",
+        "source_type": "auto",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    await db.begin()
+    try:
+        await db.upsert_insight(data)
+        await db.log_event(insight.entity_id, "insight_created", trigger="api")
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return InsightResponse(**data)
+
+
+@router.get("", response_model=InsightListResponse)
+async def list_insights(
+    maturity: Annotated[
+        Optional[str],
+        Query(description="Filter by maturity: seedling | sprout | mature"),
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> InsightListResponse:
+    """List all insights with optional maturity filter and pagination."""
+    if maturity is not None and maturity not in ("seedling", "sprout", "mature"):
+        raise HTTPException(status_code=422, detail="Invalid maturity value")
+
+    items, total = await db.list_insights(maturity=maturity, limit=limit, offset=offset)
+    has_more = (offset + limit) < total
+    return InsightListResponse(
+        items=[InsightListItem(**item) for item in items],
+        total=total,
+        has_more=has_more,
+    )
+
+
+@router.get("/{insight_id}", response_model=InsightResponse)
+async def get_insight(
+    insight_id: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> InsightResponse:
+    """Fetch a single insight by ID."""
+    insight = await db.get_insight(insight_id)
+    if not insight:
+        raise HTTPException(status_code=404, detail="Insight not found")
+    return InsightResponse(**insight)
+
+
+@router.patch("/{insight_id}/maturity", response_model=InsightResponse)
+async def upgrade_maturity(
+    insight_id: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> InsightResponse:
+    """Advance maturity to next level (seedling→sprout→mature).
+
+    Returns 422 if already fully mature.
+    """
+    insight = await db.get_insight(insight_id)
+    if not insight:
+        raise HTTPException(status_code=404, detail="Insight not found")
+
+    current = insight["maturity"]
+    next_m = _next_maturity(current)
+    if next_m is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Already fully mature",
+        )
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    updated = {**insight, "maturity": next_m, "updated_at": now}
+
+    await db.begin()
+    try:
+        await db.upsert_insight(updated)
+        await db.log_event(
+            insight["entity_id"],
+            "maturity_upgraded",
+            trigger="api",
+            extra={"from": current, "to": next_m},
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return InsightResponse(**updated)

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -207,14 +207,83 @@ class Database:
             await self.conn.execute("PRAGMA foreign_keys=ON")
         # NOTE: no commit() here — caller controls transaction
 
+    async def get_insight(self, insight_id: str) -> Optional[dict[str, Any]]:
+        """Fetch an insight row by ID, or None if not found."""
+        async with self.conn.execute(
+            "SELECT * FROM insights WHERE id = ?", (insight_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        return dict(row) if row else None
+
+    async def upsert_insight(self, data: dict[str, Any]) -> None:
+        """Insert or update an insight. Caller manages transaction."""
+        await self.conn.execute(
+            """
+            INSERT INTO insights (id, entity_id, title, content, maturity, source_type, created_at, updated_at)
+            VALUES (:id, :entity_id, :title, :content, :maturity, :source_type, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                title = excluded.title,
+                content = excluded.content,
+                maturity = excluded.maturity,
+                updated_at = excluded.updated_at
+            """,
+            {
+                "id": data["id"],
+                "entity_id": data["entity_id"],
+                "title": data["title"],
+                "content": data.get("content"),
+                "maturity": data.get("maturity", "seedling"),
+                "source_type": data.get("source_type", "auto"),
+                "created_at": data["created_at"],
+                "updated_at": data["updated_at"],
+            },
+        )
+
+    async def list_insights(
+        self,
+        maturity: Optional[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return paginated list of insights with optional maturity filter.
+
+        Returns (items, total_count).
+        """
+        conditions = []
+        params: list[Any] = []
+
+        if maturity:
+            conditions.append("maturity = ?")
+            params.append(maturity)
+
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        count_sql = f"SELECT COUNT(*) FROM insights WHERE {where_clause}"
+        async with self.conn.execute(count_sql, params) as cur:
+            total = (await cur.fetchone())[0]
+
+        sql = f"""
+            SELECT id, entity_id, title, maturity, source_type, created_at, updated_at
+            FROM insights
+            WHERE {where_clause}
+            ORDER BY updated_at DESC
+            LIMIT ? OFFSET ?
+        """
+        params.extend([limit, offset])
+        async with self.conn.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+
+        return [dict(row) for row in rows], total
+
     async def log_event(
-        self, entity_id: str, event_type: str, trigger: Optional[str] = None
+        self, entity_id: str, event_type: str, trigger: Optional[str] = None, extra: Optional[dict] = None
     ) -> None:
         """Log a timeline event. Caller manages transaction."""
         now = datetime.now(tz=timezone.utc).isoformat()
+        meta = json.dumps(extra) if extra else None
         await self.conn.execute(
-            "INSERT INTO timeline_events (entity_id, event_type, trigger, created_at) VALUES (?, ?, ?, ?)",
-            (entity_id, event_type, trigger, now),
+            "INSERT INTO timeline_events (entity_id, event_type, trigger, created_at, metadata) VALUES (?, ?, ?, ?, ?)",
+            (entity_id, event_type, trigger, now, meta),
         )
         # NOTE: no commit() here — caller controls transaction
 

--- a/compass-api/src/db/schema.sql
+++ b/compass-api/src/db/schema.sql
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS timeline_events (
     entity_id   TEXT NOT NULL REFERENCES entities(id),
     event_type  TEXT NOT NULL,
     trigger     TEXT,
+    metadata    TEXT,
     created_at  TEXT NOT NULL
 );
 
@@ -82,6 +83,21 @@ CREATE TABLE IF NOT EXISTS score_history (
     reason       TEXT NOT NULL,
     created_at   TEXT NOT NULL
 );
+
+-- Insights
+CREATE TABLE IF NOT EXISTS insights (
+    id              TEXT PRIMARY KEY,
+    entity_id       TEXT NOT NULL REFERENCES entities(id),
+    title           TEXT NOT NULL,
+    content         TEXT,
+    maturity        TEXT NOT NULL DEFAULT 'seedling',
+    source_type     TEXT DEFAULT 'auto',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_insights_entity ON insights(entity_id);
+CREATE INDEX IF NOT EXISTS idx_insights_maturity ON insights(maturity);
 
 -- FTS5 full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(

--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src import config
 from src.db.database import Database, set_db
-from src.api import entities, scores, feed, agent, graph, fetch, search
+from src.api import entities, scores, feed, agent, graph, fetch, search, insights
 
 # Global DB — initialized once at startup
 db = Database()
@@ -42,6 +42,7 @@ app.include_router(agent.router)
 app.include_router(graph.router)
 app.include_router(fetch.router)
 app.include_router(search.router)
+app.include_router(insights.router)
 
 
 @app.get("/health")

--- a/compass-api/tests/conftest.py
+++ b/compass-api/tests/conftest.py
@@ -39,6 +39,8 @@ async def db(db_path: Path):
     set_db(database)
     yield database
     await conn.close()
+    # Wipe DB file so next test gets fresh state
+    db_path.unlink(missing_ok=True)
 
 
 @pytest.fixture

--- a/compass-api/tests/integration/test_api_insights.py
+++ b/compass-api/tests/integration/test_api_insights.py
@@ -1,0 +1,224 @@
+"""Integration tests for Insight-1 CRUD endpoints."""
+import pytest
+from starlette.testclient import TestClient
+
+
+class TestInsightCreate:
+    _counter = 0
+
+    @classmethod
+    def _vault(cls):
+        cls._counter += 1
+        return f"/tmp/insight_vault_{cls._counter}"
+
+    def test_create_insight_basic(self, client: TestClient):
+        """POST /insights creates an insight with seedling maturity."""
+        vp = self._vault()
+        entity_resp = client.post("/entities", json={
+            "id": "test-entity-insight-1",
+            "title": "Test Entity for Insight",
+            "entity_type": "knowledge",
+            "content": "some content",
+            "vault_path": vp,
+        })
+        assert entity_resp.status_code == 200
+
+        resp = client.post("/insights", json={
+            "entity_id": "test-entity-insight-1",
+            "title": "My First Insight",
+            "content": "Insight content here",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "My First Insight"
+        assert data["maturity"] == "seedling"
+        assert data["entity_id"] == "test-entity-insight-1"
+        assert data["source_type"] == "auto"
+        assert "id" in data
+
+    def test_create_insight_entity_not_found(self, client: TestClient):
+        """POST /insights with non-existent entity returns 404."""
+        resp = client.post("/insights", json={
+            "entity_id": "nonexistent-entity",
+            "title": "Orphan Insight",
+        })
+        assert resp.status_code == 404
+
+    def test_create_insight_logged_event(self, client: TestClient):
+        """Creating an insight also logs a timeline event."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-insight-2",
+            "title": "Test Entity 2",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        resp = client.post("/insights", json={
+            "entity_id": "test-entity-insight-2",
+            "title": "Logged Insight",
+        })
+        assert resp.status_code == 200
+
+
+class TestInsightList:
+    _counter = 0
+
+    @classmethod
+    def _vault(cls):
+        cls._counter += 1
+        return f"/tmp/insight_list_vault_{cls._counter}"
+
+    def test_list_insights_empty(self, client: TestClient):
+        """GET /insights on fresh DB returns empty list."""
+        resp = client.get("/insights")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+        assert data["has_more"] is False
+
+    def test_list_insights_returns_created(self, client: TestClient):
+        """GET /insights returns created insights."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-insight-list",
+            "title": "Test Entity List",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        client.post("/insights", json={
+            "entity_id": "test-entity-insight-list",
+            "title": "List Test Insight",
+            "content": "content",
+        })
+        resp = client.get("/insights")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1
+        assert any(i["title"] == "List Test Insight" for i in data["items"])
+
+    def test_list_insights_pagination(self, client: TestClient):
+        """Pagination params work correctly."""
+        resp = client.get("/insights?limit=5&offset=0")
+        assert resp.status_code == 200
+        assert "has_more" in resp.json()
+
+    def test_list_insights_maturity_filter(self, client: TestClient):
+        """Maturity filter returns only matching insights."""
+        resp = client.get("/insights?maturity=seedling")
+        assert resp.status_code == 200
+        for item in resp.json()["items"]:
+            assert item["maturity"] == "seedling"
+
+    def test_list_insights_invalid_maturity(self, client: TestClient):
+        """Invalid maturity returns 422."""
+        resp = client.get("/insights?maturity=invalid")
+        assert resp.status_code == 422
+
+
+class TestInsightGet:
+    _counter = 0
+
+    @classmethod
+    def _vault(cls):
+        cls._counter += 1
+        return f"/tmp/insight_get_vault_{cls._counter}"
+
+    def test_get_insight_found(self, client: TestClient):
+        """GET /insights/{id} returns the insight."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-insight-get",
+            "title": "Get Test Entity",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        create_resp = client.post("/insights", json={
+            "entity_id": "test-entity-insight-get",
+            "title": "Get Test Insight",
+        })
+        insight_id = create_resp.json()["id"]
+
+        resp = client.get(f"/insights/{insight_id}")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Get Test Insight"
+
+    def test_get_insight_not_found(self, client: TestClient):
+        """GET /insights/{id} for nonexistent returns 404."""
+        resp = client.get("/insights/nonexistent-insight-id")
+        assert resp.status_code == 404
+
+
+class TestInsightMaturityUpgrade:
+    _counter = 0
+
+    @classmethod
+    def _vault(cls):
+        cls._counter += 1
+        return f"/tmp/insight_upgrade_vault_{cls._counter}"
+
+    def test_upgrade_seedling_to_sprout(self, client: TestClient):
+        """PATCH maturity advances seedling → sprout."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-upgrade-1",
+            "title": "Upgrade Test Entity",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        create_resp = client.post("/insights", json={
+            "entity_id": "test-entity-upgrade-1",
+            "title": "Upgrade Test Insight",
+        })
+        insight_id = create_resp.json()["id"]
+
+        resp = client.patch(f"/insights/{insight_id}/maturity")
+        assert resp.status_code == 200
+        assert resp.json()["maturity"] == "sprout"
+
+    def test_upgrade_sprout_to_mature(self, client: TestClient):
+        """Second PATCH advances sprout → mature."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-upgrade-2",
+            "title": "Upgrade Test Entity 2",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        create_resp = client.post("/insights", json={
+            "entity_id": "test-entity-upgrade-2",
+            "title": "Two-Step Upgrade Insight",
+        })
+        insight_id = create_resp.json()["id"]
+
+        client.patch(f"/insights/{insight_id}/maturity")
+        resp = client.patch(f"/insights/{insight_id}/maturity")
+        assert resp.status_code == 200
+        assert resp.json()["maturity"] == "mature"
+
+    def test_upgrade_mature_returns_422(self, client: TestClient):
+        """Patching a mature insight returns 422 'already fully mature'."""
+        vp = self._vault()
+        client.post("/entities", json={
+            "id": "test-entity-upgrade-3",
+            "title": "Upgrade Test Entity 3",
+            "entity_type": "knowledge",
+            "vault_path": vp,
+        })
+        create_resp = client.post("/insights", json={
+            "entity_id": "test-entity-upgrade-3",
+            "title": "Already Mature Insight",
+        })
+        insight_id = create_resp.json()["id"]
+
+        client.patch(f"/insights/{insight_id}/maturity")
+        client.patch(f"/insights/{insight_id}/maturity")
+
+        resp = client.patch(f"/insights/{insight_id}/maturity")
+        assert resp.status_code == 422
+        assert "fully mature" in resp.json()["detail"].lower()
+
+    def test_upgrade_nonexistent_returns_404(self, client: TestClient):
+        """Patching nonexistent insight returns 404."""
+        resp = client.patch("/insights/nonexistent-id/maturity")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

### Insight-1 (#63)
- POST /insights - create insight, maturity=seedling, auto-logs timeline event
- GET /insights - paginated list + maturity filter
- GET /insights/{id} - fetch single
- PATCH /insights/{id}/maturity - state machine (seedling-sprout-mature)
- insights table + metadata column added to schema

### Timeline-2 (#60)
- GET /entities/timeline - time-window entity query with per-entity latest event

### Also fixed
- graph.py missing from typing import Annotated import

## Tests
30/30 passing.