### PR TITLE
fix: use await fetchall() instead of sync cursor iteration

### DIFF
--- a/compass-api/src/api/graph.py
+++ b/compass-api/src/api/graph.py
@@ -86,7 +86,8 @@ async def get_neighbors(
             """,
             out_params,
         )
-        for row in out_cur:
+        out_rows = await out_cur.fetchall()
+        for row in out_rows:
             tid = row["target_id"]
             if tid not in visited and len(visited) < MAX_NODES:
                 visited.add(tid)
@@ -123,7 +124,8 @@ async def get_neighbors(
             """,
             in_params,
         )
-        for row in in_cur:
+        in_rows = await in_cur.fetchall()
+        for row in in_rows:
             sid = row["source_id"]
             if sid not in visited and len(visited) < MAX_NODES:
                 visited.add(sid)
@@ -195,7 +197,8 @@ async def get_path(
             """,
             (node_id, node_id),
         )
-        for row in cur:
+        rows = await cur.fetchall()
+        for row in rows:
             neighbor = row["target_id"] if row["direction"] == "outgoing" else row["source_id"]
             if neighbor == to_entity:
                 full_path = path + [neighbor]


### PR DESCRIPTION
**Bug-1 Fix**: graph neighbors returning 500 Cursor not iterable error.

`aiosqlite.Cursor` requires `await cursor.fetchall()` for synchronous iteration — the code was using bare `for row in cursor` which does not work with async cursors.

Changed all cursor iterations in `get_neighbors()` and `get_path()` to use `await cursor.fetchall()` before looping.