### PR TITLE
fix: register decay router in main.py

### DIFF
--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src import config
 from src.db.database import Database, set_db
-from src.api import entities, scores, feed, agent, graph, fetch, search, insights
+from src.api import entities, scores, feed, agent, graph, fetch, search, insights, decay
 
 # Global DB — initialized once at startup
 db = Database()
@@ -43,6 +43,7 @@ app.include_router(graph.router)
 app.include_router(fetch.router)
 app.include_router(search.router)
 app.include_router(insights.router)
+app.include_router(decay.router)
 
 
 @app.get("/health")


### PR DESCRIPTION
**Bug-2 Fix**: Decay endpoints returning 404.

The `decay` router was imported and defined but never included in the FastAPI app. Added `app.include_router(decay.router)` in main.py.