### PR TITLE
feat: add Database.get_score() method

### DIFF
--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -324,6 +324,14 @@ class Database:
 
     # ---- read operations ----
 
+    async def get_score(self, entity_id: str) -> Optional[dict[str, Any]]:
+        """Fetch a score row by entity_id, or None if not found."""
+        async with self.conn.execute(
+            "SELECT * FROM scores WHERE entity_id = ?", (entity_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        return dict(row) if row else None
+
     async def get_entity(self, entity_id: str) -> Optional[dict[str, Any]]:
         """Fetch an entity row by ID, or None if not found."""
         async with self.conn.execute(


### PR DESCRIPTION
**Newly found bug during testing**.

The decay preview endpoint calls `db.get_score(entity_id)` to read the current score row, but the method was missing from the Database class, causing `AttributeError: 'Database' object has no attribute 'get_score'`.

Added `get_score(entity_id) -> Optional[dict]` which executes `SELECT * FROM scores WHERE entity_id = ?`.