### PR TITLE
feat: P3-AutoRelate-1 hybrid related entity recommendation (#95)

### DIFF
--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -713,3 +713,48 @@ async def get_entity_timeline(
         for row in rows
     ]
     return EntityTimelineResponse(entity_id=entity_id, items=items, total=total)
+
+
+# ---- P3-AutoRelate-1: GET /entities/{id}/related ----
+
+class RelatedEntityItem(BaseModel):
+    id: str
+    title: str
+    entity_type: str
+    category: str
+    vault_path: str
+    final_score: Optional[float]
+    related_score: float
+    tags: list[str] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+
+
+class RelatedResponse(BaseModel):
+    entity_id: str
+    items: list[RelatedEntityItem]
+    count: int
+
+
+@router.get("/{entity_id}/related")
+async def get_related_entities(
+    entity_id: str,
+    limit: Annotated[int, Query(ge=1, le=50)] = 10,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> RelatedResponse:
+    """Return hybrid-scored related entities for an entity.
+
+    Hybrid scoring (0.4 + 0.3 + 0.3 = 1.0 max):
+    - Content similarity: FTS5 same-category title match (weight 0.4)
+    - Tag co-occurrence: shared tags > 2 (weight 0.3)
+    - Graph proximity: 2 hops, strength > 0.5 (weight 0.3)
+    """
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    items = await db.get_related_entities(entity_id, limit=limit)
+    return RelatedResponse(
+        entity_id=entity_id,
+        items=[RelatedEntityItem(**item) for item in items],
+        count=len(items),
+    )

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -495,6 +495,108 @@ class Database:
             [r["source_id"] for r in in_rows],
         )
 
+    async def get_related_entities(self, entity_id: str, limit: int = 10) -> list[dict[str, Any]]:
+        """Hybrid related-entity recommendation for an entity.
+
+        Combines:
+        - Content similarity (FTS5, same category): weight 0.4
+        - Tag co-occurrence (shared tags > 2): weight 0.3
+        - Graph proximity (2 hops, strength > 0.5): weight 0.3
+        """
+        entity = await self.get_entity(entity_id)
+        if not entity:
+            return []
+
+        scores: dict[str, float] = {}
+
+        # 1. Content similarity via FTS5 (same category, top 5)
+        async with self.conn.execute(
+            """
+            SELECT e.id, e.title, e.category, s.final_score
+            FROM entities_fts f
+            JOIN entities e ON e.id = f.id
+            LEFT JOIN scores s ON s.entity_id = e.id
+            WHERE entities_fts MATCH ? AND e.category = ? AND e.id != ?
+            ORDER BY rank
+            LIMIT 5
+            """,
+            (entity["title"], entity["category"], entity_id),
+        ) as cur:
+            for row in await cur.fetchall():
+                rid = row["id"]
+                scores[rid] = scores.get(rid, 0) + 0.4
+
+        # 2. Tag co-occurrence (shared tags > 2)
+        async with self.conn.execute(
+            """
+            SELECT t1.entity_id AS other_id, COUNT(*) AS shared_tags
+            FROM taggings t1
+            JOIN taggings t2 ON t1.tag = t2.tag AND t2.entity_id = ?
+            WHERE t1.entity_id != ?
+            GROUP BY t1.entity_id
+            HAVING shared_tags > 2
+            LIMIT 10
+            """,
+            (entity_id, entity_id),
+        ) as cur:
+            for row in await cur.fetchall():
+                rid = row["other_id"]
+                # Normalize: tag count 3→0.3, 4→0.4, etc. capped at 1.0
+                tag_score = min(row["shared_tags"] * 0.1, 1.0)
+                scores[rid] = scores.get(rid, 0) + 0.3 * tag_score
+
+        # 3. Graph proximity (2 hops, strength > 0.5)
+        async with self.conn.execute(
+            """
+            WITH one_hop AS (
+                SELECT target_id FROM "references" WHERE source_id = ? AND strength > 0.5
+            ),
+            two_hop AS (
+                SELECT r.target_id
+                FROM "references" r
+                JOIN one_hop h ON r.source_id = h.target_id
+                WHERE r.target_id != ? AND r.strength > 0.5
+            )
+            SELECT DISTINCT target_id FROM two_hop LIMIT 10
+            """,
+            (entity_id, entity_id),
+        ) as cur:
+            for row in await cur.fetchall():
+                rid = row["target_id"]
+                scores[rid] = scores.get(rid, 0) + 0.3
+
+        if not scores:
+            return []
+
+        # Sort by combined score, fetch entity details
+        sorted_ids = sorted(scores, key=lambda x: scores[x], reverse=True)[:limit]
+        placeholders = ",".join("?" * len(sorted_ids))
+        async with self.conn.execute(
+            f"""
+            SELECT e.id, e.title, e.entity_type, e.category, e.vault_path,
+                   s.final_score, e.created_at, e.updated_at
+            FROM entities e
+            LEFT JOIN scores s ON s.entity_id = e.id
+            WHERE e.id IN ({placeholders})
+            """,
+            sorted_ids,
+        ) as cur:
+            rows = await cur.fetchall()
+
+        items = []
+        for row in rows:
+            item = dict(row)
+            item["related_score"] = round(scores.get(item["id"], 0), 3)
+            # Attach tags
+            async with self.conn.execute(
+                "SELECT tag FROM taggings WHERE entity_id = ?", (item["id"],)
+            ) as tag_cur:
+                item["tags"] = [r[0] for r in await tag_cur.fetchall()]
+            items.append(item)
+
+        items.sort(key=lambda x: x["related_score"], reverse=True)
+        return items
+
 
 # ---- FastAPI dependency ----
 


### PR DESCRIPTION
## Objective

`GET /entities/{id}/related` 接口，基于内容相似度 + 标签共现 + 图谱距离推荐关联实体。

## Hybrid Scoring (综合得分 = 1.0 满分)

| 来源 | 权重 | 说明 |
|------|------|------|
| 内容相似度（FTS5 同 category） | 0.4 | BM25 匹配同 category title |
| 标签共现（共享标签 > 2） | 0.3 | 标签重叠数量归一化 |
| 图谱距离（2 跳，strength > 0.5） | 0.3 | 2 跳内强关联实体 |

## Changes

- `Database.get_related_entities()`: 混合打分推荐，Top 10
- `GET /entities/{id}/related`: 新端点，返回 `items[]` + `count`
- `RelatedEntityItem`: 包含 `related_score`（原始混合分）和 `tags`

## Test

```bash
cd Compass && ./compass-api/.venv/bin/pytest compass-api/tests/ -v -x
```

Closes #95