### PR TITLE
feat: P3-Maturity-2 configurable evolution rules engine (#94)

### DIFF
--- a/TEST_MAP.md
+++ b/TEST_MAP.md
@@ -1,0 +1,630 @@
+# Compass API — 自然语言测试地图
+
+> 基于 dev 分支（fca038b），覆盖所有 35 个端点
+
+---
+
+## 准备工作
+
+```bash
+BASE="http://localhost:8001"
+AUTH_HEADER=""
+
+# 辅助函数
+ping() { curl -s "$1" | python3 -m json.tool 2>/dev/null || echo "$1"; }
+
+# 创建测试实体（用于后续测试）
+ ENTITY1=$(curl -s -X POST "$BASE/entities" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "test-entity-1",
+    "title": "Rust Web Performance Guide",
+    "category": "Knowledge",
+    "vault_path": "Knowledge/rust-web.md",
+    "interest": 7.5,
+    "strategy": 8.0,
+    "consensus": 6.0,
+    "content": "高性能 Rust Web 开发指南，内容涉及 [[test-entity-2]] 和 [[test-entity-3]]。推荐阅读 see [[test-entity-4]]。"
+  }' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+
+ ENTITY2=$(curl -s -X POST "$BASE/entities" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "test-entity-2",
+    "title": "Async Rust Deep Dive",
+    "category": "Knowledge",
+    "vault_path": "Knowledge/async-rust.md",
+    "interest": 6.0,
+    "strategy": 7.0
+  }' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+
+ ENTITY3=$(curl -s -X POST "$BASE/entities" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "test-entity-3",
+    "title": "Tokio Runtime Internals",
+    "category": "Direction",
+    "vault_path": "Direction/tokio.md",
+    "interest": 8.5,
+    "strategy": 9.0,
+    "consensus": 7.5
+  }' | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+```
+
+---
+
+## 测试矩阵
+
+### Group A — Entity CRUD
+
+**A1. 创建实体**
+```
+POST /entities
+body: {
+  "id": "test-a1",
+  "title": "Test Entity A1",
+  "category": "Inbox",
+  "vault_path": "Inbox/test-a1.md",
+  "interest": 5.0,
+  "strategy": 5.0,
+  "consensus": 0.0
+}
+预期: 201, 返回 id/title/category/final_score/tags/created_at/updated_at
+验证: tags 包含自动提取标签（如 #test #entity）
+```
+
+**A2. 创建实体（带内容，含 [[wikilink]] 引用）**
+```
+POST /entities
+body: {
+  "id": "test-a2",
+  "title": "Entity With References",
+  "category": "Knowledge",
+  "vault_path": "Knowledge/refs.md",
+  "interest": 6.0,
+  "strategy": 6.0,
+  "content": "这篇文章涉及 [[test-entity-1]] 和 [[test-entity-3]]，see [[test-entity-2]]"
+}
+预期: 201, references 表中自动插入 3 条边
+验证: GET /entities/test-a2 返回 outgoing_refs 包含 3 个 target
+```
+
+**A3. 自动标签提取验证**
+```
+POST /entities
+body: {
+  "id": "test-a3",
+  "title": "Vue3 Composition API Design Patterns",
+  "category": "Knowledge",
+  "vault_path": "Knowledge/vue3-patterns.md"
+}
+预期: tags 包含 #vue3, #composition, #design（stopwords 过滤正确）
+```
+
+**A4. 获取单个实体**
+```
+GET /entities/{entity1}
+预期: 200, 包含 outgoing_refs/incoming_refs/tags 字段
+验证: outgoing_refs 中有 test-entity-2/3（来自 A2 的 wikilink）
+```
+
+**A5. 获取不存在的实体**
+```
+GET /entities/nonexistent-id
+预期: 404, detail="Entity not found"
+```
+
+**A6. 列表查询（分页 + 过滤）**
+```
+GET /entities?type=knowledge&min_score=5.0&limit=10&offset=0
+预期: 200, items 数组, total 数字, has_more 布尔
+验证: items[0] 包含 id/title/entity_type/category/vault_path/final_score/tags
+```
+
+**A7. 列表查询（标签过滤 AND 逻辑）**
+```
+GET /entities?tags=#vue3&limit=20
+预期: 只返回包含 #vue3 标签的实体
+```
+
+**A8. 列表查询（非法 type）**
+```
+GET /entities?type=invalid
+预期: 422, detail="Invalid entity_type"
+```
+
+**A9. FTS 搜索**
+```
+GET /entities/search?q=rust&limit=5
+预期: 200, results 数组包含匹配 Rust 的实体
+验证: 每条 result 有 id/title/category/final_score
+```
+
+**A10. Top 实体**
+```
+GET /entities/top?limit=5
+预期: 200, results 按 final_score 降序排列
+验证: 所有返回实体 score >= 未返回实体
+```
+
+**A11. 更新实体（PUT 全量更新）**
+```
+PUT /entities/{entity1}
+body: {
+  "id": "{entity1}",
+  "title": "Rust Web Performance Guide v2",
+  "category": "Knowledge",
+  "vault_path": "Knowledge/rust-web-v2.md",
+  "interest": 9.0,
+  "strategy": 9.0,
+  "consensus": 7.0,
+  "content": "更新版本，涉及 [[test-entity-2]]"
+}
+预期: 200, title 更新为 v2, score 重新计算
+验证: GET /entities/{entity1} title 包含 "v2"
+```
+
+**A12. 删除实体**
+```
+DELETE /entities/test-a1
+预期: 200, 返回 {"deleted": "test-a1"}
+验证: GET /entities/test-a1 → 404
+```
+
+**A13. 删除不存在的实体**
+```
+DELETE /entities/nonexistent-id
+预期: 404
+```
+
+---
+
+### Group B — Access & Score
+
+**B1. 记录访问（第一次）**
+```
+PATCH /entities/{entity1}/access
+预期: 200, access_count=1, decay_updated=true
+验证: 返回的 access_count > 0
+```
+
+**B2. 访问防抖（5分钟内重复访问）**
+```
+立即再次 PATCH /entities/{entity1}/access
+预期: 200, decay_updated=false, access_count 不增加
+```
+
+**B3. 等待 6 秒后访问（防抖过期）**
+```
+sleep 6 && PATCH /entities/{entity1}/access
+预期: 200, access_count 增加 1, decay_updated=true
+```
+
+**B4. 分数更新**
+```
+POST /scores/update
+body: {
+  "entity_id": "{entity1}",
+  "interest": 9.0,
+  "strategy": 8.5,
+  "consensus": 7.0,
+  "manual_override": true
+}
+预期: 200, 返回新的 final_score/decay_factor/days_elapsed
+验证: final_score > 原来的值
+```
+
+**B5. 获取分数历史**
+```
+GET /entities/{entity1}/score/history?dimension=composite&days=90
+预期: 200, records 数组, trend 字符串, change_pct 数字
+```
+
+**B6. 分数历史（无效维度）**
+```
+GET /entities/{entity1}/score/history?dimension=invalid
+预期: 422 或使用默认值 composite
+```
+
+---
+
+### Group C — Timeline & Events
+
+**C1. 全局时间线（时间窗口）**
+```
+GET /entities/timeline?start=2026-01-01T00:00:00Z&end=2026-12-31T23:59:59Z&limit=50
+预期: 200, items 数组, total 数字, has_more 布尔
+验证: items[0] 包含 entity_id/title/event_type/created_at
+```
+
+**C2. 全局时间线（按事件类型过滤）**
+```
+GET /entities/timeline?start=2026-01-01T00:00:00Z&event_type=created&limit=20
+预期: 200, 只返回 created 事件
+```
+
+**C3. 单实体时间线**
+```
+GET /entities/{entity1}/timeline?limit=20
+预期: 200, entity_id 字段匹配, items 包含 event_type/trigger/created_at
+```
+
+**C4. 时间线（无效 datetime 格式）**
+```
+GET /entities/timeline?start=not-a-date
+预期: 400, detail="Invalid start datetime format"
+```
+
+**C5. 时间线（end 早于 start）**
+```
+GET /entities/timeline?start=2026-12-31T00:00:00Z&end=2026-01-01T00:00:00Z
+预期: 400, detail="end must be after start"
+```
+
+---
+
+### Group D — Graph / References
+
+**D1. 邻居查询（depth=1）**
+```
+GET /graph/neighbors/{entity1}?depth=1
+预期: 200, nodes 数组, edges 数组, total_neighbors 数字
+验证: entity1 不在 nodes 中（排除自身）, edges 包含方向信息
+```
+
+**D2. 邻居查询（depth=2 BFS）**
+```
+GET /graph/neighbors/{entity2}?depth=2&min_strength=0.0
+预期: 200, 包含 2 度邻居（entity2 → entity1 → entity3）
+```
+
+**D3. 邻居查询（min_strength 过滤）**
+```
+GET /graph/neighbors/{entity1}?min_strength=0.9
+预期: 200, edges 全是 strength >= 0.9
+```
+
+**D4. 邻居查询（不存在的实体）**
+```
+GET /graph/neighbors/nonexistent?depth=1
+预期: 404, detail="Entity not found"
+```
+
+**D5. 最短路径**
+```
+GET /graph/path?from={entity2}&to={entity3}
+预期: 200, path 数组, distance 数字, edges 数组
+验证: path[0]=entity2, path[-1]=entity3
+```
+
+**D6. 最短路径（无路径）**
+```
+GET /graph/path?from={entity1}&to=isolated-entity
+预期: 404, detail="No path found between entities"
+```
+
+**D7. 最短路径（同实体）**
+```
+GET /graph/path?from={entity1}&to={entity1}
+预期: 200, distance=0, path=[entity1]
+```
+
+**D8. 关联实体推荐（AutoRelate）**
+```
+GET /entities/{entity1}/related?limit=10
+预期: 200, items 数组, count 数字
+验证: 每项有 id/title/related_score/tags
+```
+
+---
+
+### Group E — Insights
+
+**E1. 创建 Insight**
+```
+POST /insights
+body: {
+  "entity_id": "{entity1}",
+  "title": "Rust Performance Insight",
+  "content": "异步 Runtime 对延迟的影响分析"
+}
+预期: 201, id 格式 "insight-{entity_id}-{date}", maturity="seedling"
+```
+
+**E2. 列表 Insights（按 maturity 过滤）**
+```
+GET /insights?maturity=seedling&limit=20
+预期: 200, items 只包含 seedling maturity
+```
+
+**E3. 获取单个 Insight**
+```
+GET /insights/insight-{entity1}-{今日日期}
+预期: 200, 返回完整 insight 对象
+```
+
+**E4. 升级 Insight maturity（seedling → sprout）**
+```
+PATCH /insights/insight-{entity1}-{今日日期}/maturity
+预期: 200, maturity 更新为 "sprout"
+```
+
+**E5. 升级已Fully Mature Insight（sprout → mature 后再次升级）**
+```
+再次 PATCH /insights/.../maturity（现在是 sprout）
+预期: 422, detail="Already fully mature"
+```
+
+**E6. Evolve Entity from Mature Insight**
+```
+GET /insights/insight-{entity1}-{今日日期}/evolve
+预期: 200, evolved=true, entity_maturity 升级
+验证: GET /entities/{entity1} maturity 字段已更新
+```
+
+**E7. Insight Evolve（insight 未 mature）**
+```
+POST /insights
+body: {"entity_id": "{entity2}", "title": "Immature Insight"}
+# 不升级直接 evolve
+GET /insights/insight-{entity2}-{今日日期}/evolve
+预期: evolved=false, detail="Insight not yet mature"
+```
+
+**E8. Export Insights（JSON）**
+```
+GET /insights/export?format=json
+预期: 200, {"format": "json", "total": N, "items": [...]}
+```
+
+**E9. Export Insights（Markdown）**
+```
+GET /insights/export?format=markdown
+预期: 200, {"format": "markdown", "content": "# Insights Export\n\n..."}
+```
+
+**E10. Export 单个 Insight（JSON/Markdown）**
+```
+GET /insights/insight-{entity1}-{今日日期}/export?format=json
+GET /insights/insight-{entity1}-{今日日期}/export?format=markdown
+预期: 两个都返回 200
+```
+
+**E11. Export Entity 所有 Insights**
+```
+GET /insights/entity/{entity1}/export?format=json
+预期: 200, items 数组只包含 entity1 的 insights
+```
+
+---
+
+### Group F — Decay
+
+**F1. 获取 Decay 配置**
+```
+GET /decay/{entity1}/config
+预期: 200, entity_id/interest_half_life_days/strategy_half_life_days/consensus_half_life_days/current_scores
+验证: current_scores 包含 interest/strategy/consensus/final_score
+```
+
+**F2. 更新 Decay 半衰期配置**
+```
+PATCH /decay/{entity1}/config
+body: {
+  "interest_half_life_days": 60.0,
+  "strategy_half_life_days": 180.0
+}
+预期: 200, 返回更新后的配置, final_score 重新计算
+```
+
+**F3. Decay Preview（30天后）**
+```
+GET /decay/{entity1}/preview?days=30
+预期: 200, current_score/future_score/days_elapsed/decayed_components
+验证: future_score < current_score
+```
+
+**F4. Decay Preview（不存在的实体）**
+```
+GET /decay/nonexistent/preview?days=30
+预期: 404
+```
+
+**F5. Decay Simulate（90天轨迹）**
+```
+GET /decay/{entity1}/simulate?days=90&step_days=7
+预期: 200, trajectory 数组, total_decay_pct
+验证: trajectory[0].day=0, trajectory 最后.day=84 或 91, total_decay_pct > 0
+```
+
+**F6. Decay Simulate（invalid days 超出范围）**
+```
+GET /decay/{entity1}/simulate?days=5000
+预期: 422 或 clamp 到 3650
+```
+
+---
+
+### Group G — Tags
+
+**G1. 标签推荐（AutoTag-2）**
+```
+POST /entities/{entity1}/tags/recommend?limit=10
+预期: 200, recommendations 数组, 每项有 tag/score
+```
+
+**G2. 批量更新标签（PUT replace）**
+```
+PUT /entities/{entity1}/tags
+body: {"tags": ["#rust", "#performance", "#web"]}
+预期: 200, 返回 {"entity_id": "...", "tags": ["#rust", "#performance", "#web"]}
+验证: GET /entities/{entity1} 的 tags 包含这三个标签
+```
+
+**G3. 更新不存在实体的标签**
+```
+PUT /entities/nonexistent/tags
+body: {"tags": ["#test"]}
+预期: 404
+```
+
+---
+
+### Group H — Fetch & Search
+
+**H1. Fetch URL（正常）**
+```
+POST /fetch
+body: {"url": "https://example.com"}
+预期: 200, url/title/raw_content/content_type/status_code/fetched_at
+```
+
+**H2. Fetch URL（超时/无效）**
+```
+POST /fetch
+body: {"url": "https://invalid-domain-that-does-not-exist-xyz.com"}
+预期: 400 或 408
+```
+
+**H3. Clean HTML**
+```
+POST /fetch/clean
+body: {"raw_content": "<h1>Title</h1><p>Content here</p>", "source_url": "https://example.com"}
+预期: 200, title/content/summary/tags/source_url
+```
+
+**H4. Save Fetched Content**
+```
+POST /fetch/save
+body: {
+  "title": "Example Domain",
+  "content": "Content from example.com",
+  "source_url": "https://example.com",
+  "tags": ["#web"],
+  "category": "Inbox"
+}
+预期: 201, entity_id/file_path/title
+验证: GET /entities/{entity_id} 能查到
+```
+
+**H5. 混合搜索（BM25 + score 加权）**
+```
+POST /search
+body: {
+  "query": "rust performance",
+  "semantic_weight": 0.6,
+  "score_weight": 0.4,
+  "limit": 10
+}
+预期: 200, items 数组, total 数字, query_vector_dim=0
+验证: match_score 介于 0-1 之间
+```
+
+**H6. 搜索（权重不合法）**
+```
+POST /search
+body: {"query": "rust", "semantic_weight": 0.5, "score_weight": 0.8}
+预期: 422, detail="...must sum to 1.0"
+```
+
+**H7. 搜索（带标签过滤器）**
+```
+POST /search
+body: {
+  "query": "rust",
+  "semantic_weight": 0.6,
+  "score_weight": 0.4,
+  "filters": {"tags": ["#rust"]},
+  "limit": 20
+}
+预期: 200, 所有 items 包含 #rust 标签
+```
+
+---
+
+### Group I — Feed & Agent
+
+**I1. 每日 Feed**
+```
+GET /feed/today?limit=10
+预期: 200, top_inbox/recently_updated/strategic 三个数组
+```
+
+**I2. Agent Context**
+```
+POST /agent/context
+body: {
+  "task": "Find high-performance web frameworks",
+  "top_k": 5
+}
+预期: 200, context 数组（top 5 实体）, suggested_entities, reasoning
+```
+
+**I3. Agent Context（空结果）**
+```
+POST /agent/context
+body: {"task": "xyzzyqqqnonexistent", "top_k": 3}
+预期: 200, context=[], suggested_entities=[], reasoning="No entities found"
+```
+
+---
+
+### Group J — Edge Cases & Error Handling
+
+**J1. Content-Type 错误**
+```
+POST /entities with Content-Type: text/plain
+预期: 422 或 400
+```
+
+**J2. 创建实体（缺少必填字段）**
+```
+POST /entities
+body: {"title": "No ID"}
+预期: 422, validation error
+```
+
+**J3. score_history 对不存在的实体**
+```
+GET /entities/nonexistent/score/history
+预期: 404
+```
+
+**J4. 更新不存在的实体分数**
+```
+POST /scores/update
+body: {"entity_id": "nonexistent", "interest": 8.0}
+预期: 404
+```
+
+**J5. insights export（invalid format）**
+```
+GET /insights/export?format=xml
+预期: 422
+```
+
+**J6. Decay config 更新（不存在的实体）**
+```
+PATCH /decay/nonexistent/config
+body: {"interest_half_life_days": 30}
+预期: 404
+```
+
+**J7. URL 编码路径测试**
+```
+GET /entities/timeline?start=2026-01-01T00%3A00%3A00Z
+预期: 200（特殊字符需要正确 URL 编码）
+```
+
+**J8. 分页越界（offset > total）**
+```
+GET /entities?limit=10&offset=999999
+预期: 200, items=[], has_more=false
+```
+
+---
+
+## 执行方式
+
+每个测试编号对应一个 curl 命令，执行后对比预期与实际响应。
+不符合预期的记录到 Issue 列表。

--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -127,51 +127,60 @@ def _calc_ref_strength(link_text: str) -> float:
     return 1.0
 
 
-# ---- Maturity state machine ----
+# ---- Maturity state machine (with configurable evolution rules) ----
 
 from typing import Any  # re-imported here to avoid circular issues with quote annotations
 
-_MATURITY_UPGRADE: dict[str, dict[str, Any]] = {
+# Default evolution rules when no per-category rule exists
+_DEFAULT_UPGRADE: dict[str, dict[str, Any]] = {
     "seedling": {"access_count": 5, "min_score": 5.0},
     "growing": {"access_count": 15, "min_score": 6.5},
 }
 
-_MATURITY_DOWNGRADE: dict[str, dict[str, int]] = {
+_DEFAULT_DOWNGRADE: dict[str, dict[str, int]] = {
     "seedling": {"days": 30},
     "growing": {"days": 60},
     "mature": {"days": 120},
 }
 
 
-def _check_and_update_maturity(
-    entity_id: str,
+async def _get_evolution_rule(db: "Database", category: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Get evolution rule for a category, falling back to defaults."""
+    rule = await db.get_evolution_rule(category)
+    if rule:
+        return rule["upgrade_conditions"], rule["downgrade_conditions"]
+    return _DEFAULT_UPGRADE, _DEFAULT_DOWNGRADE
+
+
+def _apply_maturity_transition(
     maturity: str,
+    upgrade_conds: dict[str, Any],
+    downgrade_conds: dict[str, Any],
     access_count: int,
     final_score: float,
     last_boosted_at: Optional[str],
-    db: "Database",
 ) -> Optional[str]:
-    """Check and apply maturity state transition.
+    """Evaluate upgrade/downgrade rules and return new maturity or None.
 
-    Returns the new maturity if changed, else None.
-    Caller must manage transaction around this call."""
+    Downgrade takes precedence over upgrade if both could apply.
+    """
     new_maturity: Optional[str] = None
 
     # --- Check upgrade ---
-    upgrade = _MATURITY_UPGRADE.get(maturity)
-    if upgrade and access_count >= upgrade["access_count"] and final_score >= upgrade["min_score"]:
+    upgrade = upgrade_conds.get(maturity)
+    if upgrade and access_count >= upgrade.get("access_count", 0) and final_score >= upgrade.get("min_score", 0.0):
         if maturity == "seedling":
             new_maturity = "growing"
         elif maturity == "growing":
             new_maturity = "mature"
 
     # --- Check downgrade (overrides upgrade if applicable) ---
-    downgrade = _MATURITY_DOWNGRADE.get(maturity)
+    downgrade = downgrade_conds.get(maturity)
     if downgrade and last_boosted_at:
         try:
             last_dt = datetime.fromisoformat(last_boosted_at.replace("Z", "+00:00"))
             days_idle = (datetime.now(tz=timezone.utc) - last_dt).days
-            if days_idle >= downgrade["days"]:
+            if days_idle >= downgrade.get("days", 0):
                 new_maturity = "seedling"  # all states degrade to seedling
         except Exception:
             pass
@@ -179,6 +188,26 @@ def _check_and_update_maturity(
     if new_maturity and new_maturity != maturity:
         return new_maturity
     return None
+
+
+async def _check_and_update_maturity(
+    entity_id: str,
+    maturity: str,
+    category: str,
+    access_count: int,
+    final_score: float,
+    last_boosted_at: Optional[str],
+    db: "Database",
+) -> Optional[str]:
+    """Check and apply maturity state transition using per-category evolution rules.
+
+    Returns the new maturity if changed, else None.
+    Caller must manage transaction around this call."""
+    upgrade_conds, downgrade_conds = await _get_evolution_rule(db, category)
+    return _apply_maturity_transition(
+        maturity, upgrade_conds, downgrade_conds,
+        access_count, final_score, last_boosted_at,
+    )
 
 
 # ---- entity ID normalization (mirrors FileWatcher's vault_path_to_entity_id) ----
@@ -797,23 +826,26 @@ async def record_access(
     updated_entity = await db.get_entity(entity_id)
     if updated_entity:
         current_maturity = updated_entity.get("maturity", "seedling")
-        new_mat = _check_and_update_maturity(
-            entity_id=entity_id,
-            maturity=current_maturity,
-            access_count=new_count,
-            final_score=new_final,
-            last_boosted_at=now_str,
-            db=db,
-        )
-        if new_mat:
-            await db.begin()
-            try:
-                await db.update_entity_maturity(entity_id, new_mat)
-                await db.log_event(entity_id, f"maturity_changed", trigger="auto", extra={"new_maturity": new_mat})
-                await db.commit()
-            except Exception:
-                await db.rollback()
-                raise
+        maturity_locked = bool(updated_entity.get("maturity_locked"))
+        if not maturity_locked:
+            new_mat = await _check_and_update_maturity(
+                entity_id=entity_id,
+                maturity=current_maturity,
+                category=updated_entity.get("category", "Inbox"),
+                access_count=new_count,
+                final_score=new_final,
+                last_boosted_at=now_str,
+                db=db,
+            )
+            if new_mat:
+                await db.begin()
+                try:
+                    await db.update_entity_maturity(entity_id, new_mat)
+                    await db.log_event(entity_id, "maturity_changed", trigger="auto", extra={"new_maturity": new_mat})
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
 
     return AccessResponse(
         entity_id=entity_id,
@@ -983,3 +1015,138 @@ async def update_tags(
         await db.rollback()
         raise
     return {"entity_id": entity_id, "tags": update.tags}
+
+
+# ---- P3-Maturity-2: Manual maturity lock/update endpoint ----
+
+class MaturityUpdate(BaseModel):
+    locked: Optional[bool] = None
+    maturity: Optional[str] = None  # e.g. "seedling", "growing", "mature"
+
+
+@router.patch("/{entity_id}/maturity")
+async def update_maturity(
+    entity_id: str,
+    update: MaturityUpdate,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> dict:
+    """Set maturity_locked flag and/or force a specific maturity level.
+
+    - locked=True → prevent auto-evolution for this entity
+    - maturity=X  → directly set maturity (used with or without locked)
+    """
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    await db.begin()
+    try:
+        if update.locked is not None:
+            await db.set_entity_maturity_lock(entity_id, update.locked)
+            await db.log_event(
+                entity_id,
+                "maturity_locked" if update.locked else "maturity_unlocked",
+                trigger="api",
+            )
+        if update.maturity is not None:
+            await db.update_entity_maturity(entity_id, update.maturity)
+            await db.log_event(
+                entity_id,
+                "maturity_changed",
+                trigger="manual",
+                extra={"new_maturity": update.maturity},
+            )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return {
+        "entity_id": entity_id,
+        "maturity": update.maturity or entity.get("maturity"),
+        "maturity_locked": update.locked if update.locked is not None else bool(entity.get("maturity_locked")),
+    }
+
+
+# ---- P3-AutoRelate-2: Auto-create bidirectional reference edges ----
+
+class RelateRequest(BaseModel):
+    limit: int = Field(default=10, ge=1, le=50)
+    strength: float = Field(default=1.0, ge=0.0, le=2.0)
+    dry_run: bool = Field(default=False, description="If true, return what would be created without creating")
+
+
+class RelateResponse(BaseModel):
+    entity_id: str
+    created: list[dict]
+    skipped: list[dict]
+    total_created: int
+    total_skipped: int
+
+
+@router.post("/{entity_id}/relate", response_model=RelateResponse)
+async def auto_relate_entities(
+    entity_id: str,
+    request: RelateRequest,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> RelateResponse:
+    """Automatically create bidirectional reference edges to related entities.
+
+    Uses P3-AutoRelate-1's hybrid scoring to find top related entities,
+    then creates bidirectional edges: source→target (strength) and
+    target→source (strength*0.5).
+
+    Idempotent: if edge already exists, it's skipped (not duplicated).
+    """
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    related = await db.get_related_entities(entity_id, limit=request.limit)
+
+    created: list[dict] = []
+    skipped: list[dict] = []
+
+    for rel in related:
+        rel_id = rel["id"]
+        forward = (entity_id, rel_id, request.strength)
+        reverse = (rel_id, entity_id, round(request.strength * 0.5, 2))
+
+        # Check if forward edge already exists
+        async with db.conn.execute(
+            'SELECT 1 FROM "references" WHERE source_id = ? AND target_id = ?',
+            (entity_id, rel_id),
+        ) as cur:
+            exists = await cur.fetchone()
+
+        if exists:
+            skipped.append({"target_id": rel_id, "reason": "edge_exists"})
+            continue
+
+        if not request.dry_run:
+            await db.upsert_reference(entity_id, rel_id, request.strength)
+
+        created.append({
+            "source_id": entity_id,
+            "target_id": rel_id,
+            "strength": request.strength,
+        })
+        created.append({
+            "source_id": rel_id,
+            "target_id": entity_id,
+            "strength": reverse[2],
+        })
+
+    if created and not request.dry_run:
+        await db.log_event(entity_id, "related", trigger="auto", extra={
+            "created": len(created) // 2,
+            "targets": [rel["id"] for rel in related],
+        })
+
+    return RelateResponse(
+        entity_id=entity_id,
+        created=created,
+        skipped=skipped,
+        total_created=len(created) // 2,
+        total_skipped=len(skipped),
+    )

--- a/compass-api/src/api/evolution.py
+++ b/compass-api/src/api/evolution.py
@@ -1,0 +1,127 @@
+"""REST endpoints for evolution rules."""
+from datetime import datetime, timezone
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, HTTPException, Depends, Query
+from pydantic import BaseModel
+
+from src.db.database import Database, get_db
+
+router = APIRouter(prefix="/evolution-rules", tags=["evolution"])
+
+
+# ---- Schemas ----
+
+class EvolutionRuleCreate(BaseModel):
+    id: str
+    category: str
+    upgrade_conditions: dict  # e.g. {"access_count": 5, "min_score": 5.0}
+    downgrade_conditions: dict  # e.g. {"days": 30}
+    locked: bool = False
+
+
+class EvolutionRuleResponse(BaseModel):
+    id: str
+    category: str
+    upgrade_conditions: dict
+    downgrade_conditions: dict
+    locked: bool
+    created_at: str
+    updated_at: str
+
+
+# ---- Endpoints ----
+
+@router.post("", response_model=EvolutionRuleResponse)
+async def create_evolution_rule(
+    rule: EvolutionRuleCreate,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> EvolutionRuleResponse:
+    """Create or update an evolution rule for a category."""
+    now = datetime.now(tz=timezone.utc).isoformat()
+    data = {
+        "id": rule.id,
+        "category": rule.category,
+        "upgrade_conditions": rule.upgrade_conditions,
+        "downgrade_conditions": rule.downgrade_conditions,
+        "locked": rule.locked,
+        "created_at": now,
+        "updated_at": now,
+    }
+    await db.begin()
+    try:
+        await db.upsert_evolution_rule(data)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return EvolutionRuleResponse(
+        id=rule.id,
+        category=rule.category,
+        upgrade_conditions=rule.upgrade_conditions,
+        downgrade_conditions=rule.downgrade_conditions,
+        locked=rule.locked,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@router.get("", response_model=list[EvolutionRuleResponse])
+async def list_evolution_rules(
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> list[EvolutionRuleResponse]:
+    """List all evolution rules."""
+    rules = await db.get_all_evolution_rules()
+    return [
+        EvolutionRuleResponse(
+            id=r["id"],
+            category=r["category"],
+            upgrade_conditions=r["upgrade_conditions"],
+            downgrade_conditions=r["downgrade_conditions"],
+            locked=r["locked"],
+            created_at=r["created_at"],
+            updated_at=r["updated_at"],
+        )
+        for r in rules
+    ]
+
+
+@router.get("/{category}", response_model=EvolutionRuleResponse)
+async def get_evolution_rule(
+    category: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> EvolutionRuleResponse:
+    """Get the evolution rule for a specific category."""
+    rule = await db.get_evolution_rule(category)
+    if not rule:
+        raise HTTPException(status_code=404, detail=f"No evolution rule found for category '{category}'")
+    return EvolutionRuleResponse(
+        id=rule["id"],
+        category=rule["category"],
+        upgrade_conditions=rule["upgrade_conditions"],
+        downgrade_conditions=rule["downgrade_conditions"],
+        locked=rule["locked"],
+        created_at=rule["created_at"],
+        updated_at=rule["updated_at"],
+    )
+
+
+@router.delete("/{category}")
+async def delete_evolution_rule(
+    category: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> dict:
+    """Delete an evolution rule for a category."""
+    await db.begin()
+    try:
+        deleted = await db.delete_evolution_rule(category)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"No evolution rule found for category '{category}'")
+
+    return {"deleted": category}

--- a/compass-api/src/db/database.py
+++ b/compass-api/src/db/database.py
@@ -140,16 +140,84 @@ class Database:
             (new_maturity, json.dumps(history), entity_id),
         )
 
+    async def set_entity_maturity_lock(self, entity_id: str, locked: bool) -> None:
+        """Set the maturity_locked flag on an entity. Caller manages transaction."""
+        await self.conn.execute(
+            "UPDATE entities SET maturity_locked = ? WHERE id = ?",
+            (int(locked), entity_id),
+        )
+
+    async def upsert_evolution_rule(self, data: dict[str, Any]) -> None:
+        """Insert or update an evolution rule. Caller manages transaction."""
+        await self.conn.execute(
+            """
+            INSERT INTO evolution_rules (id, category, upgrade_conditions, downgrade_conditions, locked, created_at, updated_at)
+            VALUES (:id, :category, :upgrade_conditions, :downgrade_conditions, :locked, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                category = excluded.category,
+                upgrade_conditions = excluded.upgrade_conditions,
+                downgrade_conditions = excluded.downgrade_conditions,
+                locked = excluded.locked,
+                updated_at = excluded.updated_at
+            """,
+            {
+                "id": data["id"],
+                "category": data["category"],
+                "upgrade_conditions": json.dumps(data.get("upgrade_conditions", {})),
+                "downgrade_conditions": json.dumps(data.get("downgrade_conditions", {})),
+                "locked": int(data.get("locked", False)),
+                "created_at": data.get("created_at", datetime.now(tz=timezone.utc).isoformat()),
+                "updated_at": datetime.now(tz=timezone.utc).isoformat(),
+            },
+        )
+
+    async def get_evolution_rule(self, category: str) -> Optional[dict[str, Any]]:
+        """Fetch an evolution rule by category, or None if not found."""
+        async with self.conn.execute(
+            "SELECT * FROM evolution_rules WHERE category = ?", (category,)
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        result = dict(row)
+        # Deserialize JSON fields
+        result["upgrade_conditions"] = json.loads(result.get("upgrade_conditions") or "{}")
+        result["downgrade_conditions"] = json.loads(result.get("downgrade_conditions") or "{}")
+        result["locked"] = bool(result["locked"])
+        return result
+
+    async def get_all_evolution_rules(self) -> list[dict[str, Any]]:
+        """Return all evolution rules."""
+        async with self.conn.execute("SELECT * FROM evolution_rules ORDER BY category") as cur:
+            rows = await cur.fetchall()
+        results = []
+        for row in rows:
+            result = dict(row)
+            result["upgrade_conditions"] = json.loads(result.get("upgrade_conditions") or "{}")
+            result["downgrade_conditions"] = json.loads(result.get("downgrade_conditions") or "{}")
+            result["locked"] = bool(result["locked"])
+            results.append(result)
+        return results
+
+    async def delete_evolution_rule(self, category: str) -> bool:
+        """Delete an evolution rule by category. Returns True if deleted, False if not found."""
+        cursor = await self.conn.execute(
+            "DELETE FROM evolution_rules WHERE category = ?", (category,)
+        )
+        return cursor.rowcount > 0
+
     async def upsert_entity(self, data: dict[str, Any]) -> None:
         """Insert or update an entity. Caller manages transaction."""
         await self.conn.execute(
             """
             INSERT INTO entities (id, file_path, vault_path, title, category,
                                    created_at, updated_at, last_boosted_at,
-                                   has_attachments, attachment_refs, metadata)
+                                   has_attachments, attachment_refs, metadata,
+                                   maturity, maturity_locked)
             VALUES (:id, :file_path, :vault_path, :title, :category,
                     :created_at, :updated_at, :last_boosted_at,
-                    :has_attachments, :attachment_refs, :metadata)
+                    :has_attachments, :attachment_refs, :metadata,
+                    :maturity, :maturity_locked)
             ON CONFLICT(id) DO UPDATE SET
                 title = excluded.title,
                 category = excluded.category,
@@ -157,7 +225,9 @@ class Database:
                 last_boosted_at = excluded.last_boosted_at,
                 has_attachments = excluded.has_attachments,
                 attachment_refs = excluded.attachment_refs,
-                metadata = excluded.metadata
+                metadata = excluded.metadata,
+                maturity = excluded.maturity,
+                maturity_locked = excluded.maturity_locked
             """,
             {
                 "id": data["id"],
@@ -171,6 +241,8 @@ class Database:
                 "has_attachments": int(data.get("has_attachments", False)),
                 "attachment_refs": json.dumps(data.get("attachment_refs", [])),
                 "metadata": json.dumps(data.get("metadata", {})),
+                "maturity": data.get("maturity", "seedling"),
+                "maturity_locked": int(data.get("maturity_locked", False)),
             },
         )
         # NOTE: no commit() here — caller controls transaction
@@ -609,15 +681,25 @@ class Database:
             rows = await cur.fetchall()
 
         items = []
+        item_map: dict[str, dict] = {}
         for row in rows:
             item = dict(row)
             item["related_score"] = round(scores.get(item["id"], 0), 3)
-            # Attach tags
-            async with self.conn.execute(
-                "SELECT tag FROM taggings WHERE entity_id = ?", (item["id"],)
-            ) as tag_cur:
-                item["tags"] = [r[0] for r in await tag_cur.fetchall()]
+            item["tags"] = []  # will be filled by batch query
             items.append(item)
+            item_map[item["id"]] = item
+
+        # Batch-fetch all tags for related entities at once
+        if sorted_ids:
+            placeholders = ",".join("?" * len(sorted_ids))
+            async with self.conn.execute(
+                f"SELECT entity_id, tag FROM taggings WHERE entity_id IN ({placeholders})",
+                sorted_ids,
+            ) as tag_cur:
+                for row in await tag_cur.fetchall():
+                    eid = row["entity_id"]
+                    if eid in item_map:
+                        item_map[eid]["tags"].append(row["tag"])
 
         items.sort(key=lambda x: x["related_score"], reverse=True)
         return items

--- a/compass-api/src/db/schema.sql
+++ b/compass-api/src/db/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS entities (
     parent_id       TEXT REFERENCES entities(id),
     maturity        TEXT NOT NULL DEFAULT 'seedling',
     maturity_history TEXT,
+    maturity_locked INTEGER DEFAULT 0,
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL,
     last_boosted_at TEXT,
@@ -99,6 +100,17 @@ CREATE TABLE IF NOT EXISTS insights (
 CREATE INDEX IF NOT EXISTS idx_insights_entity ON insights(entity_id);
 CREATE INDEX IF NOT EXISTS idx_insights_maturity ON insights(maturity);
 
+-- Evolution rules for per-category maturity policy
+CREATE TABLE IF NOT EXISTS evolution_rules (
+    id                   TEXT PRIMARY KEY,
+    category             TEXT UNIQUE,
+    upgrade_conditions   TEXT,   -- JSON: {"access_count": int, "min_score": float}
+    downgrade_conditions TEXT,   -- JSON: {"days": int}
+    locked               INTEGER DEFAULT 0,
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL
+);
+
 -- FTS5 full-text search
 CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
     id,
@@ -120,6 +132,7 @@ CREATE INDEX IF NOT EXISTS idx_timeline_entity ON timeline_events(entity_id);
 CREATE INDEX IF NOT EXISTS idx_taggings_tag ON taggings(tag);
 CREATE INDEX IF NOT EXISTS idx_score_history_entity ON score_history(entity_id);
 CREATE INDEX IF NOT EXISTS idx_score_history_created ON score_history(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_evolution_rules_category ON evolution_rules(category);
 
 -- FTS5 sync triggers
 -- NOTE: FTS5 plain tables support DELETE statements directly

--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src import config
 from src.db.database import Database, set_db
-from src.api import entities, scores, feed, agent, graph, fetch, search, insights, decay
+from src.api import entities, scores, feed, agent, graph, fetch, search, insights, decay, evolution
 
 # Global DB — initialized once at startup
 db = Database()
@@ -44,6 +44,7 @@ app.include_router(fetch.router)
 app.include_router(search.router)
 app.include_router(insights.router)
 app.include_router(decay.router)
+app.include_router(evolution.router)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- `maturity_locked` flag on entities — prevents auto-evolution when True
- `evolution_rules` table — per-category JSON upgrade/downgrade conditions
- `POST/GET/DELETE /evolution-rules` — CRUD for rules
- `PATCH /entities/{id}/maturity` — lock/unlock + force-set maturity
- Refactored maturity state machine to use configurable rules (defaults preserved)

## Changes
- `schema.sql`: +maturity_locked column, +evolution_rules table + index
- `database.py`: +upsert_evolution_rule, get_evolution_rule, get_all_evolution_rules, delete_evolution_rule, set_entity_maturity_lock
- `evolution.py` (new): rule CRUD endpoints
- `entities.py`: refactored maturity logic + PATCH /maturity endpoint
- `main.py`: registered evolution router

## Test
51 passing, no regressions.