### PR TITLE
fix: DELETE entity cascade delete missing tables (#115)

### DIFF
--- a/compass-api/src/api/entities.py
+++ b/compass-api/src/api/entities.py
@@ -654,6 +654,9 @@ async def delete_entity(entity_id: str, db: Annotated[Database, Depends(get_db)]
         await db.conn.execute('DELETE FROM "references" WHERE source_id = ? OR target_id = ?', (entity_id, entity_id))
         await db.conn.execute("DELETE FROM timeline_events WHERE entity_id = ?", (entity_id,))
         await db.conn.execute("DELETE FROM scores WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM taggings WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM score_history WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM insights WHERE entity_id = ?", (entity_id,))
         await db.conn.execute("DELETE FROM entities WHERE id = ?", (entity_id,))
         await db.commit()
     except Exception:


### PR DESCRIPTION
## Bug Fix #115

**Problem:** DELETE /entities/{id} returns 500 `FOREIGN KEY constraint failed` when entity has references in taggings, score_history, or insights tables.

**Root Cause:** delete_entity handler only deleted from references, timeline_events, and scores tables before deleting the entity. Tables taggings, score_history, and insights also have FK constraints to entities(id) and were not being cleaned up.

**Fix:** Added DELETE statements for taggings, score_history, and insights before deleting the entity row.

**Testing:** Verified DELETE on entity with outgoing_refs no longer returns 500.

Closes #115