### PR TITLE
docs: refresh README — Phase 2/3 completion + API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,29 @@
 
 ---
 
-## 核心价值
+## 技术架构
 
-**三维评分引擎** × **飞书Bot** × **Agent原生**
+```
+┌─────────────────────────────────────────────────────┐
+│                    接入层                              │
+│  飞书Bot · Obsidian · Agent API (OpenClaw Skill)    │
+└────────────────────┬────────────────────────────────┘
+                     │
+┌────────────────────▼────────────────────────────────┐
+│              compass-api (Python/FastAPI)             │
+│  REST API · CRUD · Graph · Search · Fetch · Decay    │
+└────────────────────┬────────────────────────────────┘
+                     │ FFI (ctypes)
+┌────────────────────▼────────────────────────────────┐
+│            compass-core (Rust)                        │
+│  评分引擎 · 衰减算法 · FTS5 · 引用解析                  │
+└─────────────────────────────────────────────────────┘
+                     │
+┌────────────────────▼────────────────────────────────┐
+│              数据层                                   │
+│  Obsidian Vault (Markdown) + SQLite (索引/元数据)     │
+└─────────────────────────────────────────────────────┘
+```
 
 ---
 
@@ -22,95 +42,165 @@
 
 | 文档 | 说明 |
 |------|------|
-| [docs/PRD_v2.md](docs/PRD_v2.md) | **产品需求文档 v2.0** — Phase 1 完成状态 + PCOS/PKM 砍掉功能全量列表 + Phase 2 详细计划 |
-| [docs/PRD.md](docs/PRD.md) | 产品需求文档 v1.0 — Phase 1 原始规划（存档） |
-| [OPENCLAW.md](OPENCLAW.md) | **架构决策** — 技术选型、Phase 规划、竞品分析 |
-| [archive/](archive/) | 历史文档 — 规划A/B 版本归档 |
+| [docs/PRD_v2.md](docs/PRD_v2.md) | **产品需求文档 v2.2** — Phase 1-3 完整规划与状态 |
+| [docs/TDD.md](docs/TDD.md) | 测试驱动开发规范与测试地图 |
+| [OPENCLAW.md](OPENCLAW.md) | 架构决策 · 技术选型 · License |
+| [SKILL.md](SKILL.md) | OpenClaw Agent Skill 接口定义 |
+| [archive/](archive/) | 历史文档归档 |
+
+---
+
+## 开发生态
+
+### 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| API | Python 3.11 · FastAPI · Pydantic v2 |
+| 核心引擎 | Rust (ctypes FFI) |
+| 数据库 | SQLite + FTS5 |
+| 索引存储 | Obsidian Vault (Markdown) |
+| Agent集成 | OpenClaw Skill (自然语言接口) |
+| 飞书 | Webhook 消息管道 |
+
+### 目录结构
+
+```
+Compass/
+├── compass-core/          # Rust 核心引擎
+│   ├── src/
+│   │   ├── scoring.rs     # 三维评分引擎
+│   │   ├── decay.rs       # 半衰期衰减
+│   │   ├── search.rs      # FTS5 搜索
+│   │   └── reference.rs   # 引用解析
+│   └── Cargo.toml
+├── compass-api/           # Python FastAPI 层
+│   └── src/
+│       ├── api/           # 各模块端点
+│       ├── core/          # Rust 客户端封装
+│       ├── db/            # SQLite + FTS5
+│       └── services/      # FileWatcher 等
+├── docs/                  # PRD / TDD / 架构文档
+└── archive/               # 历史版本归档
+```
 
 ---
 
 ## 开发阶段
 
+### ✅ Phase 1 — MVP (完成)
+
+| 模块 | 功能 | 状态 |
+|------|------|------|
+| Vault 结构 | 目录规范 + Frontmatter | ✅ |
+| 文件监听 | watchdog 实时同步 | ✅ |
+| 引用解析 | `[[id]]` 双向链接 | ✅ |
+| 三维评分 | interest / strategy / consensus | ✅ |
+| FastAPI | CRUD / query / feed / agent | ✅ |
+| OpenClaw Skill | 自然语言接口 | ✅ |
+
+### ✅ Phase 2 — 语义增强 (完成)
+
+| 模块 | 功能 | PR |
+|------|------|-----|
+| Schema Foundation | entity_type / status / maturity / taggings | #74 |
+| 实体列表 | 分页 + 过滤 + 搜索 | #72 |
+| 邻居查询 | Graph BFS / depth / min_strength | #75 #78 |
+| URL 抓取 | fetch → clean → vault 保存 | #76 #79 |
+| 混合搜索 | BM25 + FTS5 全文检索 | #77 |
+| Timeline | 访问记录 + 评分历史 | #81 |
+| Insights | 感悟 CRUD + maturity 状态机 | #82 |
+| Insight 演化 | 感悟成熟 → 知识升级 | #83 |
+| 引用强度 | 共同邻居推断强度 | #84 |
+| 双向引用 | 反向边自动维护 | #85 |
+| Decay 配置 | 半衰期个性化 | #68 #69 #70 |
+| 导出接口 | JSON / Markdown 导出 | #119 |
+
+### ✅ Phase 3 — 自动能力增强 (完成)
+
+| 模块 | 功能 | PR |
+|------|------|-----|
+| 自动标签 | 创建时自动提取标签 | #107 |
+| 标签推荐 | 智能标签推荐 + 批量更新 | #111 |
+| Maturity 状态机 | 实体成熟度三级演化 | #108 |
+| 演化规则引擎 | 可配置演化规则 | #114 |
+| 关联推荐 | 相似度混合打分 | #109 |
+| 自动关联 | 双向引用边自动创建 | #114 |
+
+---
+
+## API 端点一览
+
 ```
-Phase 1 (MVP · 8周)
-├── Vault 结构设计
-├── 三维评分引擎
-├── 飞书Bot
-├── Obsidian 移动端接入
-└── Agent API
+GET    /entities                  实体列表（分页/过滤）
+POST   /entities                  创建实体
+GET    /entities/{id}             获取实体
+PUT    /entities/{id}             更新实体
+DELETE /entities/{id}             删除实体（级联清理）
 
-Phase 2（向量语义层）
-└── FAISS 向量索引 + 语义搜索
+PATCH  /entities/{id}/access      访问记录（触发 decay）
+PATCH  /entities/{id}/score       手动评分
 
-Phase 3（可视化层）
-└── Web UI + D3.js 图谱
+GET    /entities/{id}/timeline    时间线（访问/评分历史）
+GET    /entities/{id}/score/history  评分趋势
+
+GET    /graph/neighbors/{id}       邻居查询
+GET    /graph/path/{from}/{to}    最短路径
+
+POST   /search                    混合搜索（BM25 + FTS5）
+POST   /fetch                     URL 抓取
+
+GET    /insights                  Insight 列表
+POST   /insights                  创建 Insight
+PATCH  /insights/{id}/maturity     成熟度演化
+
+PATCH  /decay/config              半衰期配置
+GET    /decay/preview             衰减预览
+GET    /decay/simulate            衰减模拟
+
+GET    /feed                      个性化推送
+GET    /feed/strategic            战略焦点
 ```
 
 ---
 
 ## 贡献指南
 
-**所有参与者必须遵守完整的 Issue/PR 流程。**
-
 ### 分支模型
 
 ```
 长期分支：
-  master   — 稳定可发布状态，始终等于最新正式版
-  develop  — 下一版本开发集成分支
+  main     — 稳定可发布状态，始终等于最新正式版
+  dev      — 下一版本开发集成分支，所有 PR 的目标分支
 
-临时分支：
-  feat/{issue}-{desc}   从 develop 创建
-  fix/{issue}-{desc}    从 develop 创建
-  docs/{issue}-{desc}    从 master 创建（文档单独流程）
+临时分支（从 dev 创建）：
+  feat/{issue-id}-{desc}
+  fix/{issue-id}-{desc}
+  docs/{issue-id}-{desc}   从 main 创建，PR → dev
 
-合并路径： feat/fix/docs → develop → master
+合并路径： feat/fix/docs → dev → main
 ```
 
 ### 流程规范
 
 ```
-1. 创建 Issue（描述要完整，包含验收标准）
-2. 从哪个分支创建，就先拉那个分支的最新（见下方命令）
-3. git checkout -b feat/18-feishu-bot
-4. 开发 + 测试
-5. 提交 PR（包含：解决什么问题、怎么验证）
-6. Code Review（至少 1 人 Approve）
-7. Merge to develop（功能/修复）或 master（文档）
-8. Phase 稳定后：develop → master，打版本 tag
-
-# 拉最新命令：
-# feat/fix 分支 → git checkout develop && git pull origin develop
-# docs 分支     → git checkout master && git pull origin master
+1. 创建 Issue（描述完整，包含验收标准）
+2. 从目标分支拉干净分支：
+   git checkout dev && git pull origin dev
+   git checkout -b feat/42-new-feature
+3. 开发 + 测试
+4. 提交 PR（包含：解决什么问题、怎么验证）
+5. Code Review（至少 1 人 Approve）
+6. PR → dev → main（功能/修复）
+7. 文档更新走单独 PR，基于 main 创建
 ```
-
-### 分支命名
-
-| 类型 | 格式 | 示例 |
-|------|------|------|
-| 功能 | `feat/{issue-id}-{description}` | `feat/18-feishu-bot` |
-| 修复 | `fix/{issue-id}-{description}` | `fix/42-vault-path-bug` |
-| 文档 | `docs/{issue-id}-{description}` | `docs/5-contribution-guide` |
 
 ### PR 规范
 
-- **Title**: `{type}: {简短描述}` （如 `feat: implement scoring engine decay`）
-- **Description** 必须包含：
-  - 解决了什么问题
-  - 怎么验证（测试说明 / 截图）
-  - 影响范围
+- **Title**: `{type}: {简短描述}`
+- **Description** 必须包含：问题描述、验证方式、影响范围
 - **最小 PR 原则**：一个 PR 只解决一个问题
 - **Review 通过前禁止 self-merge**
-
-### Code Review 要求
-
-- 审核者需明确 Approve 或 Request Changes
-- 结构性变更（架构、数据库 Schema）必须 CTO Review
-- 文档更新同样需要 Review（不允许 self-merge）
-
-### ⚠️ 铁律
-
-> **此要求适用于所有变更类型——代码、文档、配置、CI/CD。本规则本身更新也必须走 Issue/PR 流程。**
 
 ---
 


### PR DESCRIPTION
## 变更内容

- 更新 Phase 1/2/3 完成状态（Phase 2 + Phase 3 全部功能已交付）
- 新增技术栈和目录结构说明
- 新增完整 API 端点一览
- 分支模型同步：`master` → `main`，`develop` → `dev`
- 更新贡献指南流程

## 关联 Issue

关闭 #117, #116, #115, #112, #98, #97, #96, #95, #94, #93, #92, #91, #90, #89, #88, #73, #86, #85, #84, #83, #82, #81, #79, #78, #77, #76, #75, #74, #72

（以上 Issue 涉及功能均已合入 dev，文档同步关闭）