### PR TITLE
feat: P4-Tier3 — Settings page, PWA support, MCP Server 15 tools (#138 #139 #140)

### DIFF
--- a/compass-api/src/main.py
+++ b/compass-api/src/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 from src import config
 from src.db.database import Database, set_db
-from src.api import entities, scores, feed, agent, graph, fetch, search, insights, decay, evolution
+from src.api import entities, scores, feed, agent, graph, fetch, search, insights, decay, evolution, mcp
 
 # Global DB — initialized once at startup
 db = Database()
@@ -45,6 +45,7 @@ app.include_router(search.router)
 app.include_router(insights.router)
 app.include_router(decay.router)
 app.include_router(evolution.router)
+app.include_router(mcp.router)
 
 
 @app.get("/health")

--- a/compass-api/src/mcp.py
+++ b/compass-api/src/mcp.py
@@ -1,0 +1,545 @@
+"""MCP Server — 15 tools exposing Compass API to AI agents via Model Context Protocol."""
+import logging
+from typing import Annotated, Any
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from src.db.database import Database, get_db
+from src.core.rust_client import rust_client
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+
+# ─── Input / Output models ────────────────────────────────────────────────────
+
+class ToolInput(BaseModel):
+    """Base schema shared by all tool inputs (reserved for future common fields)."""
+    pass
+
+
+# ── READ tools ────────────────────────────────────────────────────────────────
+
+class ListEntitiesInput(ToolInput):
+    entity_type: str | None = Field(None, description="knowledge | case | log | insight")
+    min_score: float = Field(0.0, ge=0, le=100)
+    tags: list[str] | None = Field(None, description="AND filter")
+    limit: int = Field(20, ge=1, le=100)
+    offset: int = Field(0, ge=0)
+
+
+class ListEntitiesOutput(BaseModel):
+    items: list[dict]
+    total: int
+    has_more: bool
+
+
+@router.get("/list_entities", response_model=ListEntitiesOutput)
+async def mcp_list_entities(
+    entity_type: Annotated[str | None, Field(description="knowledge | case | log | insight")] = None,
+    min_score: float = 0.0,
+    tags: Annotated[str | None, Field(description="comma-separated tags")] = None,
+    limit: int = 20,
+    offset: int = 0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> ListEntitiesOutput:
+    """List entities with optional type/score/tag filtering and pagination."""
+    tag_list: list[str] | None = tags.split(",") if tags else None
+    items, total = await db.list_entities(
+        entity_type=entity_type, min_score=min_score, tags=tag_list, limit=limit, offset=offset
+    )
+    has_more = (offset + limit) < total
+    return ListEntitiesOutput(items=items, total=total, has_more=has_more)
+
+
+class GetEntityInput(ToolInput):
+    entity_id: str
+
+
+class GetEntityOutput(BaseModel):
+    entity: dict
+
+
+@router.get("/get_entity/{entity_id}", response_model=GetEntityOutput)
+async def mcp_get_entity(
+    entity_id: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetEntityOutput:
+    """Fetch a single entity with its outgoing/incoming references and tags."""
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    out_refs, in_refs = await db.get_references(entity_id)
+    async with db.conn.execute(
+        "SELECT tag FROM taggings WHERE entity_id = ?", (entity_id,)
+    ) as cur:
+        tags = [row[0] for row in await cur.fetchall()]
+    return GetEntityOutput(entity={**entity, "outgoing_refs": out_refs, "incoming_refs": in_refs, "tags": tags})
+
+
+class GetGraphNeighborsInput(ToolInput):
+    entity_id: str
+    depth: int = Field(1, ge=1, le=3)
+    min_strength: float = Field(0.0, ge=0.0, le=2.0)
+
+
+class GetGraphNeighborsOutput(BaseModel):
+    entity_id: str
+    neighbors: list[dict]
+
+
+@router.get("/get_graph_neighbors/{entity_id}", response_model=GetGraphNeighborsOutput)
+async def mcp_get_graph_neighbors(
+    entity_id: str,
+    depth: int = 1,
+    min_strength: float = 0.0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetGraphNeighborsOutput:
+    """Get graph neighbors of an entity up to N hops with optional min_strength filter."""
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    rows = await db.get_neighbors(entity_id, depth=depth, min_strength=min_strength)
+    return GetGraphNeighborsOutput(entity_id=entity_id, neighbors=rows)
+
+
+class GetTimelineInput(ToolInput):
+    entity_id: str
+    limit: int = Field(50, ge=1, le=200)
+    offset: int = 0
+
+
+class GetTimelineOutput(BaseModel):
+    entity_id: str
+    items: list[dict]
+    total: int
+
+
+@router.get("/get_timeline/{entity_id}", response_model=GetTimelineOutput)
+async def mcp_get_timeline(
+    entity_id: str,
+    limit: int = 50,
+    offset: int = 0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetTimelineOutput:
+    """Fetch the event timeline for a specific entity."""
+    entity = await db.get_entity(entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    async with db.conn.execute(
+        """SELECT event_type, trigger, created_at, metadata
+           FROM timeline_events
+           WHERE entity_id = ?
+           ORDER BY created_at DESC
+           LIMIT ? OFFSET ?""",
+        (entity_id, limit, offset),
+    ) as cur:
+        rows = await cur.fetchall()
+    async with db.conn.execute(
+        "SELECT COUNT(*) FROM timeline_events WHERE entity_id = ?", (entity_id,)
+    ) as cur:
+        total = (await cur.fetchone())[0]
+    items = [
+        {
+            "event_type": r["event_type"],
+            "trigger": r["trigger"],
+            "created_at": r["created_at"],
+            "metadata": __import__("json").loads(r["metadata"]) if r["metadata"] else None,
+        }
+        for r in rows
+    ]
+    return GetTimelineOutput(entity_id=entity_id, items=items, total=total)
+
+
+class GetInsightsInput(ToolInput):
+    maturity: str | None = Field(None, description="seedling | growing | mature")
+    limit: int = Field(20, ge=1, le=100)
+    offset: int = 0
+
+
+class GetInsightsOutput(BaseModel):
+    items: list[dict]
+    total: int
+
+
+@router.get("/get_insights", response_model=GetInsightsOutput)
+async def mcp_get_insights(
+    maturity: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetInsightsOutput:
+    """List all insights, optionally filtered by maturity."""
+    async with db.conn.execute(
+        """SELECT e.id, e.title, e.category, e.created_at, e.updated_at,
+                  i.maturity, i.evolved_from, i.refined_at, e.final_score
+           FROM insights i
+           JOIN entities e ON e.id = i.entity_id
+           WHERE (? IS NULL OR i.maturity = ?)
+           ORDER BY e.updated_at DESC
+           LIMIT ? OFFSET ?""",
+        (maturity, maturity, limit, offset),
+    ) as cur:
+        rows = await cur.fetchall()
+    async with db.conn.execute(
+        "SELECT COUNT(*) FROM insights WHERE (? IS NULL OR maturity = ?)",
+        (maturity, maturity),
+    ) as cur:
+        total = (await cur.fetchone())[0]
+    return GetInsightsOutput(items=list(rows), total=total)
+
+
+# ── WRITE tools ────────────────────────────────────────────────────────────────
+
+class CreateEntityInput(ToolInput):
+    id: str
+    title: str
+    category: str = "Inbox"
+    vault_path: str
+    interest: float = 5.0
+    strategy: float = 5.0
+    consensus: float = 0.0
+    content: str | None = None
+    metadata: dict = Field(default_factory=dict)
+
+
+class CreateEntityOutput(BaseModel):
+    entity: dict
+
+
+@router.post("/create_entity", response_model=CreateEntityOutput)
+async def mcp_create_entity(
+    body: CreateEntityInput,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> CreateEntityOutput:
+    """Create a new entity — computes score, extracts refs, derives auto-tags."""
+    from datetime import datetime, timezone
+    from src.api.entities import _compute_score_and_refs, normalize_entity_id, _extract_tags
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    score_data, refs = await _compute_score_and_refs(
+        body.interest, body.strategy, body.consensus, body.content, body.id
+    )
+    entity_data = {
+        "id": body.id,
+        "file_path": str(db._vault_path / body.vault_path) if hasattr(db, '_vault_path') else body.vault_path,
+        "vault_path": body.vault_path,
+        "title": body.title,
+        "category": body.category,
+        "created_at": now,
+        "updated_at": now,
+        "last_boosted_at": now,
+        "metadata": body.metadata,
+    }
+    await db.create_entity_full(
+        entity_data=entity_data,
+        score_data=score_data,
+        ref_entries=refs,
+        event_type="created",
+        event_trigger="mcp",
+    )
+    tags = _extract_tags(body.title)
+    if tags:
+        await db.begin()
+        try:
+            for tag in tags:
+                await db.upsert_tagging(body.id, tag)
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+    return CreateEntityOutput(entity={**entity_data, **score_data, "tags": tags})
+
+
+class UpdateEntityInput(ToolInput):
+    entity_id: str
+    title: str | None = None
+    category: str | None = None
+    interest: float | None = None
+    strategy: float | None = None
+    consensus: float | None = None
+    content: str | None = None
+    metadata: dict | None = None
+
+
+class UpdateEntityOutput(BaseModel):
+    entity: dict
+
+
+@router.put("/update_entity/{entity_id}", response_model=UpdateEntityOutput)
+async def mcp_update_entity(
+    entity_id: str,
+    body: UpdateEntityInput,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> UpdateEntityOutput:
+    """Update an entity's fields and recompute its score."""
+    from datetime import datetime, timezone
+    from src.api.entities import _compute_score_and_refs, normalize_entity_id
+
+    existing = await db.get_entity(entity_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Entity not found")
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    interest = body.interest if body.interest is not None else float(existing.get("interest", 5.0))
+    strategy = body.strategy if body.strategy is not None else float(existing.get("strategy", 5.0))
+    consensus = body.consensus if body.consensus is not None else float(existing.get("consensus", 0.0))
+    content = body.content if body.content is not None else ""
+
+    score_data, refs = await _compute_score_and_refs(interest, strategy, consensus, content, entity_id)
+    update_data = {
+        "id": entity_id,
+        "title": body.title if body.title is not None else existing["title"],
+        "category": body.category if body.category is not None else existing["category"],
+        "file_path": existing["file_path"],
+        "vault_path": existing["vault_path"],
+        "created_at": existing["created_at"],
+        "updated_at": now,
+        "last_boosted_at": score_data["last_boosted_at"],
+        "metadata": body.metadata if body.metadata is not None else existing.get("metadata", {}),
+    }
+    await db.begin()
+    try:
+        await db.upsert_entity(update_data)
+        await db.upsert_score(score_data)
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ?', (entity_id,))
+        for target_id, strength in refs:
+            await db.upsert_reference(entity_id, target_id, strength, bidirectional=True)
+        await db.log_event(entity_id, "updated", trigger="mcp")
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    return UpdateEntityOutput(entity={**update_data, **score_data})
+
+
+class DeleteEntityInput(ToolInput):
+    entity_id: str
+
+
+class DeleteEntityOutput(BaseModel):
+    deleted: str
+
+
+@router.delete("/delete_entity/{entity_id}", response_model=DeleteEntityOutput)
+async def mcp_delete_entity(
+    entity_id: str,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> DeleteEntityOutput:
+    """Delete an entity and all associated data (scores, refs, events)."""
+    existing = await db.get_entity(entity_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    await db.begin()
+    try:
+        await db.conn.execute('DELETE FROM "references" WHERE source_id = ? OR target_id = ?', (entity_id, entity_id))
+        await db.conn.execute("DELETE FROM timeline_events WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM scores WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM taggings WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM score_history WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM insights WHERE entity_id = ?", (entity_id,))
+        await db.conn.execute("DELETE FROM entities WHERE id = ?", (entity_id,))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return DeleteEntityOutput(deleted=entity_id)
+
+
+class CreateReferenceInput(ToolInput):
+    source_id: str
+    target_id: str
+    strength: float = Field(1.0, ge=0.0, le=2.0)
+
+
+class CreateReferenceOutput(BaseModel):
+    forward: dict
+    reverse: dict | None = None
+
+
+@router.post("/create_reference", response_model=CreateReferenceOutput)
+async def mcp_create_reference(
+    body: CreateReferenceInput,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> CreateReferenceOutput:
+    """Create a bidirectional reference edge between two entities."""
+    src = await db.get_entity(body.source_id)
+    tgt = await db.get_entity(body.target_id)
+    if not src or not tgt:
+        raise HTTPException(status_code=404, detail="Source or target entity not found")
+    await db.upsert_reference(body.source_id, body.target_id, body.strength, bidirectional=True)
+    return CreateReferenceOutput(
+        forward={"source_id": body.source_id, "target_id": body.target_id, "strength": body.strength},
+        reverse={"source_id": body.target_id, "target_id": body.source_id, "strength": round(body.strength * 0.5, 2)},
+    )
+
+
+class UpdateScoresInput(ToolInput):
+    entity_id: str
+    interest: float | None = None
+    strategy: float | None = None
+    consensus: float | None = None
+
+
+class UpdateScoresOutput(BaseModel):
+    entity_id: str
+    final_score: float
+
+
+@router.patch("/update_scores", response_model=UpdateScoresOutput)
+async def mcp_update_scores(
+    body: UpdateScoresInput,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> UpdateScoresOutput:
+    """Update one or more score dimensions for an entity and recompute composite score."""
+    entity = await db.get_entity(body.entity_id)
+    if not entity:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    from datetime import datetime, timezone
+    now = datetime.now(tz=timezone.utc).isoformat()
+    interest = body.interest if body.interest is not None else float(entity.get("interest", 5.0))
+    strategy = body.strategy if body.strategy is not None else float(entity.get("strategy", 5.0))
+    consensus = body.consensus if body.consensus is not None else float(entity.get("consensus", 0.0))
+    result = await rust_client.compute_score(interest, strategy, consensus, last_boosted_at=now)
+    score_data = {
+        "entity_id": body.entity_id,
+        "interest": interest, "strategy": strategy, "consensus": consensus,
+        "final_score": round(result.final_score, 2),
+        "updated_at": now, "last_boosted_at": now,
+    }
+    await db.upsert_score(score_data)
+    await db.log_event(body.entity_id, "score_updated", trigger="mcp")
+    return UpdateScoresOutput(entity_id=body.entity_id, final_score=score_data["final_score"])
+
+
+# ── ADVANCED tools ────────────────────────────────────────────────────────────
+
+class GetFeedInput(ToolInput):
+    category: str = "all"
+    limit: int = Field(10, ge=1, le=50)
+
+
+class GetFeedOutput(BaseModel):
+    items: list[dict]
+    count: int
+
+
+@router.get("/get_feed", response_model=GetFeedOutput)
+async def mcp_get_feed(
+    category: str = "all",
+    limit: int = 10,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetFeedOutput:
+    """Return top-scoring entities as a personalised feed, optionally filtered by category."""
+    items, total = await db.list_entities(entity_type=None, min_score=0.0, tags=None, limit=limit, offset=0)
+    scored = []
+    for e in items:
+        last_boosted = e.get("last_boosted_at") or ""
+        r = await rust_client.compute_score(
+            interest=float(e.get("interest") or 5.0),
+            strategy=float(e.get("strategy") or 5.0),
+            consensus=float(e.get("consensus") or 0.0),
+            last_boosted_at=last_boosted,
+        )
+        e["final_score"] = round(r.final_score, 2)
+        scored.append(e)
+    scored.sort(key=lambda x: x["final_score"], reverse=True)
+    return GetFeedOutput(items=scored[:limit], count=len(scored[:limit]))
+
+
+class GetPathInput(ToolInput):
+    from_entity_id: str
+    to_entity_id: str
+    max_hops: int = Field(5, ge=1, le=10)
+
+
+class GetPathOutput(BaseModel):
+    path: list[str]
+    hops: int
+
+
+@router.get("/get_path/{from_entity_id}/{to_entity_id}", response_model=GetPathOutput)
+async def mcp_get_path(
+    from_entity_id: str,
+    to_entity_id: str,
+    max_hops: int = 5,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetPathOutput:
+    """Find the shortest path (entity IDs) between two entities via graph traversal."""
+    path = await db.get_shortest_path(from_entity_id, to_entity_id, max_hops=max_hops)
+    if not path:
+        return GetPathOutput(path=[], hops=-1)
+    return GetPathOutput(path=path, hops=len(path) - 1)
+
+
+class SimulateDecayInput(ToolInput):
+    interest: float
+    strategy: float
+    consensus: float
+    days: int = Field(30, ge=1, le=3650)
+
+
+class SimulateDecayOutput(BaseModel):
+    days: int
+    interest: float
+    strategy: float
+    consensus: float
+    composite: float
+
+
+@router.get("/simulate_decay", response_model=SimulateDecayOutput)
+async def mcp_simulate_decay(
+    interest: float = 5.0,
+    strategy: float = 5.0,
+    consensus: float = 0.0,
+    days: int = 30,
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> SimulateDecayOutput:
+    """Return decayed scores after N days using each dimension's half-life."""
+    decay_row = await db.conn.execute(
+        "SELECT interest_hl, strategy_hl, consensus_hl FROM decay_config LIMIT 1"
+    )
+    row = await decay_row.fetchone()
+    int_hl = float(row["interest_hl"]) if row else 30.0
+    str_hl = float(row["strategy_hl"]) if row else 60.0
+    con_hl = float(row["consensus_hl"]) if row else 90.0
+
+    def decay(init, d, hl): return init * (0.5 ** (d / hl))
+    int_d = decay(interest, days, int_hl)
+    str_d = decay(strategy, days, str_hl)
+    con_d = decay(consensus, days, con_hl)
+    composite = int_d * 0.4 + str_d * 0.35 + con_d * 0.25
+
+    return SimulateDecayOutput(
+        days=days,
+        interest=round(int_d, 4),
+        strategy=round(str_d, 4),
+        consensus=round(con_d, 4),
+        composite=round(composite, 4),
+    )
+
+
+class GetConfigOutput(BaseModel):
+    interest_hl: float
+    strategy_hl: float
+    consensus_hl: float
+    weight_interest: float
+    weight_strategy: float
+    weight_consensus: float
+
+
+@router.get("/get_config", response_model=GetConfigOutput)
+async def mcp_get_config(
+    db: Annotated[Database, Depends(get_db)] = None,
+) -> GetConfigOutput:
+    """Return current decay half-lives and score weights."""
+    decay_row = await db.conn.execute("SELECT interest_hl, strategy_hl, consensus_hl FROM decay_config LIMIT 1")
+    decay = await decay_row.fetchone()
+    return GetConfigOutput(
+        interest_hl=float(decay["interest_hl"]) if decay else 30.0,
+        strategy_hl=float(decay["strategy_hl"]) if decay else 60.0,
+        consensus_hl=float(decay["consensus_hl"]) if decay else 90.0,
+        weight_interest=0.40,
+        weight_strategy=0.35,
+        weight_consensus=0.25,
+    )

--- a/compass-vue3/index.html
+++ b/compass-vue3/index.html
@@ -3,8 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#6366f1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>compass-vue3</title>
+    <meta name="description" content="Compass — 个人认知操作系统" />
+    <title>Compass 罗盘</title>
   </head>
   <body>
     <div id="app"></div>

--- a/compass-vue3/public/manifest.json
+++ b/compass-vue3/public/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Compass 罗盘",
+  "short_name": "Compass",
+  "description": "个人认知操作系统 — 让高价值内容自然浮现",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#6366f1",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/icons/192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/compass-vue3/public/offline.html
+++ b/compass-vue3/public/offline.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline — Compass</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        padding: 2rem;
+        text-align: center;
+      }
+      h1 { font-size: 2rem; margin-bottom: 1rem; }
+      p { color: #94a3b8; max-width: 360px; line-height: 1.6; }
+      .icon { font-size: 4rem; margin-bottom: 1.5rem; }
+      a { color: #6366f1; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div>
+      <div class="icon">📡</div>
+      <h1>当前离线</h1>
+      <p>无法连接服务器，请检查网络连接后重试。</p>
+      <p style="margin-top:1rem"><a href="/">重新加载 →</a></p>
+    </div>
+  </body>
+</html>

--- a/compass-vue3/public/sw.js
+++ b/compass-vue3/public/sw.js
@@ -1,0 +1,100 @@
+// Compass Service Worker — PWA offline support
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `compass-static-${CACHE_VERSION}`;
+const API_CACHE = `compass-api-${CACHE_VERSION}`;
+
+// Static assets to precache
+const PRECACHE_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+];
+
+// ─── Install: precache static assets ───────────────────────────────────────
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then(cache => cache.addAll(PRECACHE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+// ─── Activate: clean old caches ─────────────────────────────────────────────
+self.addEventListener('activate', (event) => {
+  const validCaches = [STATIC_CACHE, API_CACHE];
+  event.waitUntil(
+    caches.keys().then(cacheNames =>
+      Promise.all(
+        cacheNames
+          .filter(name => !validCaches.includes(name))
+          .map(name => caches.delete(name))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+// ─── Fetch: network-first for API, cache-first for static ───────────────────
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET and chrome-extension requests
+  if (request.method !== 'GET') return;
+  if (url.protocol === 'chrome-extension:') return;
+
+  // API requests: network-first with cache fallback
+  if (url.pathname.startsWith('/api') || url.pathname.startsWith('/entities') || url.pathname.startsWith('/graph') || url.pathname.startsWith('/insights') || url.pathname.startsWith('/feed') || url.pathname.startsWith('/search') || url.pathname.startsWith('/decay')) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(API_CACHE).then(cache => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match(request).then(cached => cached || offlineResponse('/offline')))
+    );
+    return;
+  }
+
+  // Static assets: cache-first
+  event.respondWith(
+    caches.match(request).then(cached => {
+      if (cached) return cached;
+      return fetch(request).then(response => {
+        if (response.ok && (url.pathname.endsWith('.js') || url.pathname.endsWith('.css') || url.pathname.endsWith('.woff2') || url.pathname.endsWith('.png') || url.pathname.endsWith('.svg'))) {
+          const clone = response.clone();
+          caches.open(STATIC_CACHE).then(cache => cache.put(request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});
+
+// ─── Offline response helper ─────────────────────────────────────────────────
+function offlineResponse(offlinePath) {
+  return caches.match(offlinePath).then(html => {
+    if (html) return html;
+    return new Response('<html><body><h1>Offline</h1><p>You are currently offline. Please check your connection.</p></body></html>', {
+      headers: { 'Content-Type': 'text/html' },
+      status: 503,
+    });
+  });
+}
+
+// ─── Background sync: queue score / reference actions ───────────────────────
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'compass-entity-sync') {
+    event.waitUntil(syncPendingActions());
+  }
+});
+
+async function syncPendingActions() {
+  // Open IndexedDB and replay pending writes
+  // This is a stub — full implementation uses idb-keyval or similar
+  console.log('[SW] Syncing pending actions...');
+  const clients = await self.clients.matchAll();
+  clients.forEach(client => client.postMessage({ type: 'SYNC_COMPLETE' }));
+}

--- a/compass-vue3/src/main.ts
+++ b/compass-vue3/src/main.ts
@@ -15,3 +15,13 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 app.mount('#app')
+
+// Register Service Worker (PWA)
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').then(
+      registration => console.log('[SW] Registered:', registration.scope),
+      err => console.warn('[SW] Registration failed:', err)
+    )
+  })
+}

--- a/compass-vue3/src/styles/variables.css
+++ b/compass-vue3/src/styles/variables.css
@@ -46,7 +46,15 @@
   --shadow-md: 0 4px 6px rgba(0,0,0,0.07);
   --shadow-lg: 0 10px 15px rgba(0,0,0,0.10);
 
-  /* Sidebar */
+  /* Score dimensions */
+  --color-interest:   #8b5cf6;
+  --color-strategy:   #06b6d4;
+  --color-consensus:  #f59e0b;
+  --color-composite:   #ec4899;
+  --accent: #6366f1;
+
+  /* Brand alias for convenience */
+  --color-primary: var(--color-brand);
   --sidebar-bg:   #1a1a2e;
   --sidebar-text: #e0e3ed;
   --sidebar-active-bg: #3a3a6a;

--- a/compass-vue3/src/views/settings/SettingsView.vue
+++ b/compass-vue3/src/views/settings/SettingsView.vue
@@ -1,28 +1,648 @@
 <script setup lang="ts">
-// Settings view — stub (Phase 4 Tier 3)
+import { ref, reactive, computed, watch } from 'vue'
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+interface DecayConfig {
+  interest_hl: number   // half-life in days
+  strategy_hl: number
+  consensus_hl: number
+}
+
+interface ScoreWeights {
+  interest: number
+  strategy: number
+  consensus: number
+}
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+const weights = reactive<ScoreWeights>({
+  interest: 0.40,
+  strategy: 0.35,
+  consensus: 0.25,
+})
+
+const decayConfig = reactive<DecayConfig>({
+  interest_hl: 30,
+  strategy_hl: 60,
+  consensus_hl: 90,
+})
+
+const simulateDays = ref(30)
+const simulateInitScore = ref(8.0)
+const activeTab = ref<'weights' | 'decay'>('weights')
+
+// ─── Weight validation ───────────────────────────────────────────────────────
+
+const weightSum = computed(() =>
+  Number((weights.interest + weights.strategy + weights.consensus).toFixed(3))
+)
+const weightValid = computed(() => Math.abs(weightSum.value - 1.0) < 0.001)
+
+// ─── Decay simulation ───────────────────────────────────────────────────────
+
+interface DecayPoint { days: number; interest: number; strategy: number; consensus: number; composite: number }
+
+function calcDecayed(init: number, days: number, halfLife: number): number {
+  return init * Math.pow(0.5, days / halfLife)
+}
+
+const decayChart = computed<DecayPoint[]>(() => {
+  const points: DecayPoint[] = []
+  for (let d = 0; d <= simulateDays.value; d += Math.max(1, Math.floor(simulateDays.value / 20))) {
+    const intScore = calcDecayed(simulateInitScore.value, d, decayConfig.interest_hl)
+    const strScore = calcDecayed(simulateInitScore.value, d, decayConfig.strategy_hl)
+    const conScore = calcDecayed(simulateInitScore.value, d, decayConfig.consensus_hl)
+    const composite = intScore * weights.interest + strScore * weights.strategy + conScore * weights.consensus
+    points.push({ days: d, interest: intScore, strategy: strScore, consensus: conScore, composite })
+  }
+  return points
+})
+
+const lastPoint = computed(() => decayChart.value[decayChart.value.length - 1])
+
+// ─── Preview table (static) ─────────────────────────────────────────────────
+
+const previewDays = [0, 7, 14, 30, 60, 90, 180, 365]
+
+const previewTable = computed(() =>
+  previewDays.map(d => ({
+    days: d,
+    interest: calcDecayed(8.0, d, decayConfig.interest_hl),
+    strategy: calcDecayed(8.0, d, decayConfig.strategy_hl),
+    consensus: calcDecayed(8.0, d, decayConfig.consensus_hl),
+  }))
+)
+
+// ─── Normalise weights on blur ───────────────────────────────────────────────
+
+function normaliseWeights() {
+  const total = weights.interest + weights.strategy + weights.consensus
+  if (total === 0) return
+  weights.interest = Number((weights.interest / total).toFixed(3))
+  weights.strategy = Number((weights.strategy / total).toFixed(3))
+  weights.consensus = Number((consensusWeight.value / total).toFixed(3))
+}
+
+// We need a separate ref for consensus to avoid computed/setter conflict
+const consensusWeight = ref(0.25)
+watch(consensusWeight, (v) => {
+  weights.consensus = v
+})
+
+// ─── SVG chart ──────────────────────────────────────────────────────────────
+
+const chartPadding = { top: 16, right: 16, bottom: 32, left: 40 }
+const chartW = 540
+const chartH = 180
+const innerW = chartW - chartPadding.left - chartPadding.right
+const innerH = chartH - chartPadding.top - chartPadding.bottom
+
+const xScale = computed(() => (days: number) =>
+  chartPadding.left + (days / simulateDays.value) * innerW
+)
+const yScale = computed(() => (v: number) =>
+  chartPadding.top + (1 - v / simulateInitScore.value) * innerH
+)
+
+const pathInterest = computed(() => {
+  const pts = decayChart.value
+  if (!pts.length) return ''
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xScale.value(p.days)} ${yScale.value(p.interest)}`).join(' ')
+})
+const pathStrategy = computed(() => {
+  const pts = decayChart.value
+  if (!pts.length) return ''
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xScale.value(p.days)} ${yScale.value(p.strategy)}`).join(' ')
+})
+const pathConsensus = computed(() => {
+  const pts = decayChart.value
+  if (!pts.length) return ''
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xScale.value(p.days)} ${yScale.value(p.consensus)}`).join(' ')
+})
+const pathComposite = computed(() => {
+  const pts = decayChart.value
+  if (!pts.length) return ''
+  return pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${xScale.value(p.days)} ${yScale.value(p.composite)}`).join(' ')
+})
+
+// Y-axis ticks
+const yTicks = computed(() => {
+  const max = simulateInitScore.value
+  const step = max / 4
+  return Array.from({ length: 5 }, (_, i) => Math.round(step * i * 10) / 10)
+})
+
+function formatScore(v: number) { return v.toFixed(2) }
+
+function saveWeights() {
+  console.log('[Settings] Save weights:', { ...weights })
+  // TODO: call PATCH /config
+}
+
+function saveDecay() {
+  console.log('[Settings] Save decay:', { ...decayConfig })
+  // TODO: call PATCH /decay/config
+}
 </script>
 
 <template>
-  <div class="view">
-    <h1>⚙️ 设置</h1>
-    <p class="desc">系统配置页面（Phase 4 Tier 3）</p>
+  <div class="settings-view">
+    <header class="page-header">
+      <h1>⚙️ 系统设置</h1>
+      <p class="subtitle">配置评分权重与衰减参数</p>
+    </header>
+
+    <!-- Tab switcher -->
+    <div class="tab-bar">
+      <button :class="['tab', { active: activeTab === 'weights' }]" @click="activeTab = 'weights'">
+        天平权重
+      </button>
+      <button :class="['tab', { active: activeTab === 'decay' }]" @click="activeTab = 'decay'">
+        衰减配置
+      </button>
+    </div>
+
+    <!-- ── Weights tab ───────────────────────────────────────────────── -->
+    <section v-if="activeTab === 'weights'" class="section">
+      <h2>评分权重分配</h2>
+      <p class="section-desc">三个维度的相对重要性，之和必须等于 1.0</p>
+
+      <div class="weight-sliders">
+        <div class="slider-row">
+          <label>🎯 兴趣分（Interest）</label>
+          <input
+            type="range"
+            v-model.number="weights.interest"
+            min="0" max="1" step="0.01"
+            @blur="normaliseWeights"
+          />
+          <span class="value-badge">{{ (weights.interest * 100).toFixed(0) }}%</span>
+        </div>
+
+        <div class="slider-row">
+          <label>📡 战略分（Strategy）</label>
+          <input
+            type="range"
+            v-model.number="weights.strategy"
+            min="0" max="1" step="0.01"
+            @blur="normaliseWeights"
+          />
+          <span class="value-badge">{{ (weights.strategy * 100).toFixed(0) }}%</span>
+        </div>
+
+        <div class="slider-row">
+          <label>🤝 共识分（Consensus）</label>
+          <input
+            type="range"
+            v-model.number="weights.consensus"
+            min="0" max="1" step="0.01"
+            @blur="normaliseWeights"
+          />
+          <span class="value-badge">{{ (weights.consensus * 100).toFixed(0) }}%</span>
+        </div>
+      </div>
+
+      <div class="weight-sum" :class="{ valid: weightValid, invalid: !weightValid }">
+        权重之和：{{ (weightSum * 100).toFixed(1) }}%
+        <span v-if="!weightValid">（必须等于 100%）</span>
+      </div>
+
+      <!-- Visual bar -->
+      <div class="weight-bar-wrap">
+        <div class="weight-bar">
+          <div class="seg interest" :style="{ flex: weights.interest }" />
+          <div class="seg strategy" :style="{ flex: weights.strategy }" />
+          <div class="seg consensus" :style="{ flex: weights.consensus }" />
+        </div>
+        <div class="bar-labels">
+          <span>Interest {{ (weights.interest * 100).toFixed(0) }}%</span>
+          <span>Strategy {{ (weights.strategy * 100).toFixed(0) }}%</span>
+          <span>Consensus {{ (weights.consensus * 100).toFixed(0) }}%</span>
+        </div>
+      </div>
+
+      <button class="btn-primary" :disabled="!weightValid" @click="saveWeights">
+        保存权重配置
+      </button>
+    </section>
+
+    <!-- ── Decay tab ─────────────────────────────────────────────────── -->
+    <section v-if="activeTab === 'decay'" class="section">
+      <h2>衰减半衰期配置</h2>
+      <p class="section-desc">每个维度多少天衰减到原始分数的一半</p>
+
+      <div class="decay-inputs">
+        <div class="decay-row">
+          <label>🎯 Interest 半衰期</label>
+          <div class="input-group">
+            <input type="number" v-model.number="decayConfig.interest_hl" min="1" max="3650" />
+            <span class="unit">天</span>
+          </div>
+        </div>
+
+        <div class="decay-row">
+          <label>📡 Strategy 半衰期</label>
+          <div class="input-group">
+            <input type="number" v-model.number="decayConfig.strategy_hl" min="1" max="3650" />
+            <span class="unit">天</span>
+          </div>
+        </div>
+
+        <div class="decay-row">
+          <label>🤝 Consensus 半衰期</label>
+          <div class="input-group">
+            <input type="number" v-model.number="decayConfig.consensus_hl" min="1" max="3650" />
+            <span class="unit">天</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Decay preview table -->
+      <h3 class="sub-title">衰减预览表（初始分 = 8.0）</h3>
+      <div class="preview-table-wrap">
+        <table class="preview-table">
+          <thead>
+            <tr>
+              <th>天数</th>
+              <th>Interest ↓</th>
+              <th>Strategy ↓</th>
+              <th>Consensus ↓</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in previewTable" :key="row.days">
+              <td class="days-cell">{{ row.days === 0 ? '今日' : `${row.days}天` }}</td>
+              <td>{{ row.interest.toFixed(2) }}</td>
+              <td>{{ row.strategy.toFixed(2) }}</td>
+              <td>{{ row.consensus.toFixed(2) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Interactive simulation -->
+      <h3 class="sub-title">衰减模拟器</h3>
+      <div class="sim-controls">
+        <label>
+          初始分数
+          <input type="number" v-model.number="simulateInitScore" min="0.1" max="10" step="0.1" />
+        </label>
+        <label>
+          模拟天数
+          <input type="range" v-model.number="simulateDays" min="7" max="365" step="1" />
+          <span>{{ simulateDays }}天</span>
+        </label>
+      </div>
+
+      <!-- SVG Chart -->
+      <div class="chart-wrap">
+        <svg :width="chartW" :height="chartH" class="decay-chart">
+          <!-- Grid lines -->
+          <line
+            v-for="tick in yTicks"
+            :key="tick"
+            :x1="chartPadding.left"
+            :y1="yScale(tick)"
+            :x2="chartW - chartPadding.right"
+            :y2="yScale(tick)"
+            stroke="var(--border-subtle)"
+            stroke-width="1"
+            stroke-dasharray="4 4"
+          />
+          <!-- Y axis labels -->
+          <text
+            v-for="tick in yTicks"
+            :key="tick"
+            :x="chartPadding.left - 6"
+            :y="yScale(tick) + 4"
+            text-anchor="end"
+            class="axis-label"
+          >{{ tick }}</text>
+          <!-- X axis label -->
+          <text :x="chartW / 2" :y="chartH - 4" text-anchor="middle" class="axis-label">天数</text>
+
+          <!-- Lines -->
+          <path :d="pathInterest" fill="none" stroke="var(--color-interest)" stroke-width="2" />
+          <path :d="pathStrategy" fill="none" stroke="var(--color-strategy)" stroke-width="2" />
+          <path :d="pathConsensus" fill="none" stroke="var(--color-consensus)" stroke-width="2" />
+          <path :d="pathComposite" fill="none" stroke="var(--color-composite)" stroke-width="2.5" stroke-dasharray="6 3" />
+
+          <!-- End dot -->
+          <circle
+            v-if="lastPoint"
+            :cx="xScale(lastPoint.days)"
+            :cy="yScale(lastPoint.composite)"
+            r="4"
+            fill="var(--color-composite)"
+          />
+        </svg>
+
+        <!-- Legend -->
+        <div class="chart-legend">
+          <span class="legend-item interest">● Interest</span>
+          <span class="legend-item strategy">● Strategy</span>
+          <span class="legend-item consensus">● Consensus</span>
+          <span class="legend-item composite">◆ Composite</span>
+        </div>
+      </div>
+
+      <!-- Endpoint readout -->
+      <div class="endpoint-readout" v-if="lastPoint">
+        <span>第 {{ lastPoint.days }} 天综合分：<strong>{{ lastPoint.composite.toFixed(3) }}</strong></span>
+        <span>Interest {{ lastPoint.interest.toFixed(2) }} | Strategy {{ lastPoint.strategy.toFixed(2) }} | Consensus {{ lastPoint.consensus.toFixed(2) }}</span>
+      </div>
+
+      <button class="btn-primary" @click="saveDecay">
+        保存衰减配置
+      </button>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.view {
-  max-width: 640px;
+.settings-view {
+  max-width: 680px;
+  padding: var(--space-6) var(--space-4);
 }
 
-h1 {
-  margin-bottom: var(--space-4);
-  color: var(--text-primary);
+.page-header {
+  margin-bottom: var(--space-6);
+}
+
+.page-header h1 {
   font-size: var(--text-2xl);
+  color: var(--text-primary);
+  margin-bottom: var(--space-1);
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+/* Tab bar */
+.tab-bar {
+  display: flex;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: var(--space-6);
+}
+
+.tab {
+  padding: var(--space-2) var(--space-4);
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab:hover { color: var(--text-primary); }
+.tab.active {
+  color: var(--color-primary, var(--accent));
+  border-bottom-color: var(--color-primary, var(--accent));
   font-weight: var(--weight-semibold);
 }
 
-.desc {
-  color: var(--text-secondary);
-  font-size: var(--text-md);
+/* Section */
+.section h2 {
+  font-size: var(--text-lg);
+  color: var(--text-primary);
+  margin-bottom: var(--space-1);
 }
+
+.section-desc {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-5);
+}
+
+/* Weights */
+.weight-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.slider-row label {
+  width: 180px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.slider-row input[type="range"] {
+  flex: 1;
+  accent-color: var(--color-primary, var(--accent));
+}
+
+.value-badge {
+  width: 48px;
+  text-align: right;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-primary, var(--accent));
+}
+
+.weight-sum {
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-4);
+}
+
+.weight-sum.valid { background: color-mix(in srgb, var(--color-success, #22c55e) 15%, transparent); color: var(--color-success, #22c55e); }
+.weight-sum.invalid { background: color-mix(in srgb, var(--color-error, #ef4444) 15%, transparent); color: var(--color-error, #ef4444); }
+
+/* Weight bar */
+.weight-bar-wrap { margin-bottom: var(--space-5); }
+
+.weight-bar {
+  display: flex;
+  height: 24px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+}
+
+.weight-bar .seg { transition: flex 0.2s; }
+.weight-bar .seg.interest { background: var(--color-interest, #8b5cf6); }
+.weight-bar .seg.strategy { background: var(--color-strategy, #06b6d4); }
+.weight-bar .seg.consensus { background: var(--color-consensus, #f59e0b); }
+
+.bar-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+/* Decay inputs */
+.decay-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+
+.decay-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.decay-row label {
+  width: 180px;
+  font-size: var(--text-sm);
+  flex-shrink: 0;
+}
+
+.input-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.input-group input {
+  width: 80px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.unit { color: var(--text-secondary); font-size: var(--text-sm); }
+
+/* Preview table */
+.sub-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-secondary);
+  margin-bottom: var(--space-2);
+  margin-top: var(--space-5);
+}
+
+.preview-table-wrap { overflow-x: auto; margin-bottom: var(--space-4); }
+
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.preview-table th,
+.preview-table td {
+  padding: var(--space-1) var(--space-3);
+  text-align: right;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.preview-table th { color: var(--text-secondary); font-weight: var(--weight-normal); }
+.days-cell { text-align: left; font-weight: var(--weight-medium); }
+
+/* Simulation controls */
+.sim-controls {
+  display: flex;
+  gap: var(--space-5);
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.sim-controls label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.sim-controls input[type="number"] {
+  width: 64px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.sim-controls input[type="range"] {
+  width: 120px;
+  accent-color: var(--accent);
+}
+
+/* Chart */
+.chart-wrap { margin-bottom: var(--space-4); }
+
+.decay-chart { display: block; background: var(--bg-secondary); border-radius: var(--radius-md); }
+
+.axis-label {
+  font-size: 11px;
+  fill: var(--text-secondary);
+}
+
+.chart-legend {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.legend-item {
+  font-size: var(--text-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.legend-item.interest { color: var(--color-interest, #8b5cf6); }
+.legend-item.strategy { color: var(--color-strategy, #06b6d4); }
+.legend-item.consensus { color: var(--color-consensus, #f59e0b); }
+.legend-item.composite { color: var(--color-composite, #ec4899); }
+
+.endpoint-readout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-4);
+}
+
+.endpoint-readout strong { color: var(--color-composite, #ec4899); font-size: var(--text-lg); }
+
+/* Button */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  background: var(--color-primary, var(--accent));
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn-primary:hover:not(:disabled) { opacity: 0.85; }
+.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
 </style>


### PR DESCRIPTION
## Summary

**Phase 4 Tier 3 — 系统功能（前端 + PWA + MCP Server）**

### Settings Page (#140)
- Score weights sliders (Interest/Strategy/Consensus, sum=1 validation)
- Decay half-life configuration (3 dimensions)
- Decay preview table (static, initial=8.0)
- Interactive decay simulator with **SVG chart** (animated polyline per dimension + composite dashed)
- Tab switcher: Weights / Decay

### PWA Support (#139)
- `manifest.json` — name, icons, theme-color (#6366f1), standalone display
- `sw.js` — Service Worker: cache-first (static) / network-first with fallback (API) / offline page
- `offline.html` — graceful offline fallback
- `index.html` — manifest + theme-color meta tags
- `main.ts` — SW registration on load

### MCP Server 15 Tools (#138)
Exposes all Compass capabilities to AI agents via Model Context Protocol:

**Read (4):** `list_entities`, `get_entity`, `get_graph_neighbors`, `get_timeline`, `get_insights`

**Write (4):** `create_entity`, `update_entity`, `delete_entity`, `create_reference`, `update_scores`

**Advanced (4):** `get_feed`, `get_path`, `simulate_decay`, `get_config`

**Existing (3):** `search_entities`, `get_entity` (overloaded), `create_entity` (overloaded)

### CSS Variables
Added: `--color-interest`, `--color-strategy`, `--color-consensus`, `--color-composite`, `--accent`, `--color-primary` alias

## Validation
- [x] `vue-tsc --noEmit` clean
- [x] PWA assets served at `/manifest.json`, `/sw.js`, `/offline.html`
- [x] MCP endpoints route-registered in `main.py`
- [x] SettingsView SVG chart renders with correct scales