### PR TITLE
fix(skill): render 支持 stdin 读取 + BOM 容忍 (#159)

### DIFF
--- a/skills/compass/compass
+++ b/skills/compass/compass
@@ -277,13 +277,18 @@ def _render_score(data: dict) -> str:
 def action_render(params: dict) -> None:
     raw = params.get("raw")
     action_name = params.get("action")
+    # 优先 raw= 参数；未提供则从 stdin 读（支持管道，#159）
+    if not raw and not sys.stdin.isatty():
+        raw = sys.stdin.read()
     if not raw:
-        print(json.dumps({"error": "raw is required"}), file=sys.stderr)
+        print(json.dumps({"error": "raw is required (via raw= arg or stdin)"}), file=sys.stderr)
         sys.exit(1)
     if not action_name:
         print(json.dumps({"error": "action is required"}), file=sys.stderr)
         sys.exit(1)
 
+    # 容忍前导 UTF-8 BOM（stdin 来自部分 shell/管道时会带 BOM）
+    raw = raw.lstrip("\ufeff")
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## 修复 #159

`compass render raw=<JSON>` 经命令行传多行 JSON 时被 shell 拆参失败。

## 改动（skills/compass/compass）
- `raw=` 未提供且 stdin 非 tty 时，从 stdin 读 → 支持 `compass search ... | compass render action=search`
- 容忍前导 UTF-8 BOM（部分 shell 管道给 stdin 加 BOM）
- 原 `raw=` 参数方式仍兼容

## 验证（本地 demo binary）
- `search | render` → `## 搜索结果 1. [Game Theory](know-000001) — ⭐8.1分`
- `get | render` / `score | render` / `feed | render` 管道均通

Fixes #159