### PR TITLE
feat(p1): T1.4 SQLite 索引层

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ data/
 # Local vault (user-specific knowledge base content)
 vault/
 uv.lock
+
+# Local commit-message scratch
+.commit-msg.txt

--- a/compass-core/src/config.rs
+++ b/compass-core/src/config.rs
@@ -1,14 +1,17 @@
 //! 加载 compass.toml 运行时配置。
 
-use std::path::PathBuf;
-use serde::Deserialize;
 use crate::models::Weights;
+use serde::Deserialize;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub vault_path: PathBuf,
     #[serde(default = "default_port")]
     pub port: u16,
+    /// SQLite 索引库路径。相对配置文件目录解析；缺省 `.compass/index.db`。
+    #[serde(default)]
+    pub db_path: Option<PathBuf>,
     #[serde(default)]
     pub decay: DecayConfig,
     #[serde(default)]
@@ -27,11 +30,21 @@ pub struct DecayConfig {
     pub direction_layer_factor: f64,
 }
 
-fn default_port() -> u16 { 8080 }
-fn default_rate() -> f64 { 0.98 }
-fn default_floor() -> f64 { 0.5 }
-fn default_boost_protection() -> i64 { 3 }
-fn default_direction_factor() -> f64 { 0.5 }
+fn default_port() -> u16 {
+    8080
+}
+fn default_rate() -> f64 {
+    0.98
+}
+fn default_floor() -> f64 {
+    0.5
+}
+fn default_boost_protection() -> i64 {
+    3
+}
+fn default_direction_factor() -> f64 {
+    0.5
+}
 
 impl Default for DecayConfig {
     fn default() -> Self {
@@ -46,7 +59,7 @@ impl Default for DecayConfig {
 
 impl Config {
     /// 从 `COMPASS_CONFIG` 环境变量或默认 `compass.toml` 加载。
-    /// `vault_path` 若为相对路径，相对 config 文件目录解析为绝对路径。
+    /// `vault_path` 与 `db_path` 若为相对路径，相对配置文件目录解析为绝对路径。
     /// 校验权重归一化（F3）。
     pub fn load() -> anyhow::Result<Self> {
         let path = std::env::var("COMPASS_CONFIG")
@@ -54,8 +67,8 @@ impl Config {
             .unwrap_or_else(|_| PathBuf::from("compass.toml"));
         let raw = std::fs::read_to_string(&path)
             .map_err(|e| anyhow::anyhow!("读取配置失败 {}: {e}", path.display()))?;
-        let mut cfg: Config = toml::from_str(&raw)
-            .map_err(|e| anyhow::anyhow!("解析配置失败: {e}"))?;
+        let mut cfg: Config =
+            toml::from_str(&raw).map_err(|e| anyhow::anyhow!("解析配置失败: {e}"))?;
 
         // F3: 校验权重归一化
         if !cfg.weights.is_normalized() {
@@ -65,24 +78,37 @@ impl Config {
             ));
         }
 
+        // 配置文件父目录（相对路径基准）；为空时回退 CWD
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("无法获取配置文件父目录 {}", path.display()))?;
+        let base = if parent.as_os_str().is_empty() {
+            std::env::current_dir().map_err(|e| anyhow::anyhow!("获取当前目录失败: {e}"))?
+        } else {
+            parent
+                .canonicalize()
+                .map_err(|e| anyhow::anyhow!("配置文件父目录 canonicalize 失败: {e}"))?
+        };
+
+        // F2: 错误传播；解析 vault_path 为绝对
         if cfg.vault_path.is_relative() {
-            // F2: 错误传播；裸文件名时 parent 为空，回退到 CWD
-            let parent = path
-                .parent()
-                .ok_or_else(|| anyhow::anyhow!("无法获取配置文件父目录: {}", path.display()))?;
-            let base = if parent.as_os_str().is_empty() {
-                std::env::current_dir()
-                    .map_err(|e| anyhow::anyhow!("获取当前目录失败: {e}"))?
-            } else {
-                parent
-                    .canonicalize()
-                    .map_err(|e| anyhow::anyhow!("配置文件父目录 canonicalize 失败: {e}"))?
-            };
             cfg.vault_path = base.join(&cfg.vault_path);
         }
-        cfg.vault_path = cfg.vault_path.canonicalize().map_err(|e| {
-            anyhow::anyhow!("vault_path 不存在 {}: {e}", cfg.vault_path.display())
-        })?;
+        cfg.vault_path = cfg
+            .vault_path
+            .canonicalize()
+            .map_err(|e| anyhow::anyhow!("vault_path 不存在 {}: {e}", cfg.vault_path.display()))?;
+
+        // db_path：缺省 .compass/index.db，相对配置目录解析为绝对
+        let mut db_path = cfg
+            .db_path
+            .take()
+            .unwrap_or_else(|| PathBuf::from(".compass").join("index.db"));
+        if db_path.is_relative() {
+            db_path = base.join(&db_path);
+        }
+        cfg.db_path = Some(db_path);
+
         Ok(cfg)
     }
 }

--- a/compass-core/src/db.rs
+++ b/compass-core/src/db.rs
@@ -1,1 +1,917 @@
-﻿//! SQLite 索引层（T1.4 实现）：entities / score_history / timeline / entities_fts。
+//! SQLite 索引层（T1.4）：entities / score_history / timeline / entities_fts。
+//!
+//! 设计（PRD_v3.0 §4.2）：
+//! - frontmatter 是权威，SQLite 仅作索引/缓存/历史，删库可从 vault 重建。
+//! - entities 表缓存三维评分（interest/strategy/consensus + composite），列表查询免读文件。
+//! - score_history 记评分变更历史（frontmatter 不存），并供 T1.3 冷却 per-type 查询
+//!   （`last_trigger_time` 按 `id DESC` 取最新——插入序即时间序，规避 RFC3339 时区排序问题）。
+//! - entities_fts 用普通 FTS5 内部表（title, content），rowid 绑定 entities 隐式 rowid，
+//!   支持 snippet；仅 Agent/Skill 用（Obsidian 用自身搜索）。
+//! - rebuild 不清空 score_history/timeline（历史日志保留；孤儿记录可接受，T1.4 范围外）。
+
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, Row};
+
+use crate::frontmatter;
+
+/// entities 表的行镜像（vault 文件的索引缓存）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntityRow {
+    pub id: String,
+    /// 相对 vault 根的路径，正斜杠分隔。
+    pub file_path: String,
+    pub title: Option<String>,
+    pub layer: Option<String>,
+    pub status: Option<String>,
+    pub interest: Option<f64>,
+    pub strategy: Option<f64>,
+    pub consensus: Option<f64>,
+    pub composite: Option<f64>,
+    pub access_count: i64,
+    pub last_boosted_at: Option<String>,
+    pub content_hash: Option<String>,
+    /// 评分写回时间（取自 frontmatter `score.updated_at`）。
+    pub updated_at: Option<String>,
+}
+
+/// score_history 行（评分变更历史，frontmatter 不存）。
+#[derive(Debug, Clone)]
+pub struct ScoreHistoryRow {
+    pub entity_id: String,
+    pub dimension: Option<String>,
+    pub old: Option<f64>,
+    pub new: Option<f64>,
+    pub reason: Option<String>,
+    /// 触发器类型名（Cited/Linked/CaseAdded/ManualMark/ReviewCompleted/Decay/Access...）。
+    pub trigger: Option<String>,
+    pub created_at: String,
+}
+
+/// timeline 行（访问/引用/评分事件流）。
+#[derive(Debug, Clone)]
+pub struct TimelineRow {
+    pub entity_id: String,
+    pub event_type: String,
+    pub intensity: Option<f64>,
+    pub source: Option<String>,
+    pub created_at: String,
+}
+
+/// FTS 搜索命中。
+#[derive(Debug, Clone, PartialEq)]
+pub struct FtsHit {
+    pub id: String,
+    pub title: Option<String>,
+    pub snippet: Option<String>,
+}
+
+/// 全量重建统计。
+#[derive(Debug, Default, Clone)]
+pub struct RebuildStats {
+    pub indexed: u32,
+    pub skipped: u32,
+    pub duplicates: u32,
+}
+
+pub struct Db {
+    conn: Connection,
+}
+
+impl Db {
+    /// 打开（或创建）数据库文件并初始化 schema。父目录自动创建。
+    pub fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("创建 db 父目录失败 {}", parent.display()))?;
+            }
+        }
+        let conn =
+            Connection::open(path).with_context(|| format!("打开数据库失败 {}", path.display()))?;
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    /// 内存数据库（测试用）。
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()?;
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    fn init_schema(&self) -> Result<()> {
+        self.conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA foreign_keys=ON;
+             CREATE TABLE IF NOT EXISTS entities (
+               id TEXT PRIMARY KEY,
+               file_path TEXT UNIQUE NOT NULL,
+               title TEXT,
+               layer TEXT,
+               status TEXT,
+               interest REAL,
+               strategy REAL,
+               consensus REAL,
+               composite REAL,
+               access_count INTEGER NOT NULL DEFAULT 0,
+               last_boosted_at TEXT,
+               content_hash TEXT,
+               updated_at TEXT
+             );
+             CREATE TABLE IF NOT EXISTS score_history (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               entity_id TEXT NOT NULL,
+               dimension TEXT,
+               old REAL,
+               new REAL,
+               reason TEXT,
+               trigger TEXT,
+               created_at TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS timeline (
+               id INTEGER PRIMARY KEY AUTOINCREMENT,
+               entity_id TEXT NOT NULL,
+               event_type TEXT NOT NULL,
+               intensity REAL,
+               source TEXT,
+               created_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_score_history_entity ON score_history(entity_id);
+             CREATE INDEX IF NOT EXISTS idx_score_history_trigger ON score_history(entity_id, trigger);
+             CREATE INDEX IF NOT EXISTS idx_timeline_entity ON timeline(entity_id);
+             CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(title, content);",
+        )?;
+        Ok(())
+    }
+
+    /// upsert entity 并同步 FTS（`fts_content` = Markdown 正文，供 FTS 索引与 snippet）。
+    pub fn upsert_entity(&self, e: &EntityRow, fts_content: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT INTO entities
+               (id, file_path, title, layer, status, interest, strategy, consensus,
+                composite, access_count, last_boosted_at, content_hash, updated_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
+             ON CONFLICT(id) DO UPDATE SET
+               file_path=excluded.file_path, title=excluded.title, layer=excluded.layer,
+               status=excluded.status, interest=excluded.interest, strategy=excluded.strategy,
+               consensus=excluded.consensus, composite=excluded.composite,
+               access_count=excluded.access_count, last_boosted_at=excluded.last_boosted_at,
+               content_hash=excluded.content_hash, updated_at=excluded.updated_at",
+            params![
+                e.id,
+                e.file_path,
+                e.title,
+                e.layer,
+                e.status,
+                e.interest,
+                e.strategy,
+                e.consensus,
+                e.composite,
+                e.access_count,
+                e.last_boosted_at,
+                e.content_hash,
+                e.updated_at,
+            ],
+        )?;
+        let rowid: i64 = tx.query_row(
+            "SELECT rowid FROM entities WHERE id = ?1",
+            params![e.id],
+            |r| r.get(0),
+        )?;
+        // FTS5 内部表：先按 rowid 删旧（不存在也安全），再插新。
+        tx.execute("DELETE FROM entities_fts WHERE rowid = ?1", params![rowid])?;
+        tx.execute(
+            "INSERT INTO entities_fts (rowid, title, content) VALUES (?1, ?2, ?3)",
+            params![rowid, e.title.as_deref().unwrap_or(""), fts_content],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_entity(&self, id: &str) -> Result<Option<EntityRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, file_path, title, layer, status, interest, strategy, consensus,
+                    composite, access_count, last_boosted_at, content_hash, updated_at
+             FROM entities WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query(params![id])?;
+        match rows.next()? {
+            Some(r) => Ok(Some(row_to_entity(r)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// 按 composite 降序返回（NULL 自然排最后）。
+    pub fn list_entities(&self) -> Result<Vec<EntityRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, file_path, title, layer, status, interest, strategy, consensus,
+                    composite, access_count, last_boosted_at, content_hash, updated_at
+             FROM entities ORDER BY composite DESC, id",
+        )?;
+        let rows = stmt.query_map([], row_to_entity)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// 删除实体并清理其 FTS 记录。
+    pub fn delete_entity(&self, id: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        let rowid: Option<i64> = tx
+            .query_row(
+                "SELECT rowid FROM entities WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .ok();
+        if let Some(rid) = rowid {
+            tx.execute("DELETE FROM entities_fts WHERE rowid = ?1", params![rid])?;
+        }
+        tx.execute("DELETE FROM entities WHERE id = ?1", params![id])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// FTS5 搜索。query 按空白拆词、各自加引号后 AND 连接（避免 `-`/`*` 等被当作 FTS 语法）。
+    pub fn fts_search(&self, query: &str, limit: u32) -> Result<Vec<FtsHit>> {
+        let q = fts_query(query);
+        if q.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.title, snippet(entities_fts, 1, '<b>', '</b>', '...', 16) AS snip
+             FROM entities_fts f
+             JOIN entities e ON e.rowid = f.rowid
+             WHERE entities_fts MATCH ?1
+             ORDER BY rank
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![q, limit as i64], |r| {
+            Ok(FtsHit {
+                id: r.get(0)?,
+                title: r.get(1)?,
+                snippet: r.get(2)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// 该实体某触发器类型最近一次触发时间（供 T1.3 冷却判断）。
+    /// 按 score_history 自增 `id DESC` 取最新——插入序即时间序，规避 RFC3339 时区排序歧义。
+    pub fn last_trigger_time(&self, entity_id: &str, trigger: &str) -> Result<Option<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT created_at FROM score_history
+             WHERE entity_id = ?1 AND trigger = ?2
+             ORDER BY id DESC LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![entity_id, trigger])?;
+        match rows.next()? {
+            Some(r) => Ok(Some(r.get(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn insert_score_history(&self, h: &ScoreHistoryRow) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO score_history
+               (entity_id, dimension, old, new, reason, trigger, created_at)
+             VALUES (?1,?2,?3,?4,?5,?6,?7)",
+            params![
+                h.entity_id,
+                h.dimension,
+                h.old,
+                h.new,
+                h.reason,
+                h.trigger,
+                h.created_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_timeline(&self, t: &TimelineRow) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO timeline (entity_id, event_type, intensity, source, created_at)
+             VALUES (?1,?2,?3,?4,?5)",
+            params![
+                t.entity_id,
+                t.event_type,
+                t.intensity,
+                t.source,
+                t.created_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// 从 vault 全量重建索引（清空 entities + FTS，重新扫描写入）。
+    /// score_history/timeline 不清空（历史保留）。无 `id` frontmatter 的笔记跳过。
+    pub fn rebuild_from_vault(&self, vault: &Path) -> Result<RebuildStats> {
+        {
+            let tx = self.conn.unchecked_transaction()?;
+            tx.execute("DELETE FROM entities", [])?;
+            tx.execute("DELETE FROM entities_fts", [])?;
+            tx.commit()?;
+        }
+        let mut stats = RebuildStats::default();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for path in walk_md(vault)? {
+            match parse_entity(vault, &path) {
+                Ok(Some((row, body))) => {
+                    if !seen.insert(row.id.clone()) {
+                        tracing::warn!(id = %row.id, path = %path.display(), "重复 id，跳过后续文件");
+                        stats.duplicates += 1;
+                        continue;
+                    }
+                    if let Err(e) = self.upsert_entity(&row, &body) {
+                        tracing::warn!(path = %path.display(), err = %e, "索引写入失败，跳过");
+                        stats.skipped += 1;
+                    } else {
+                        stats.indexed += 1;
+                    }
+                }
+                Ok(None) => stats.skipped += 1,
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), err = %e, "解析失败，跳过");
+                    stats.skipped += 1;
+                }
+            }
+        }
+        Ok(stats)
+    }
+}
+
+fn row_to_entity(r: &Row) -> rusqlite::Result<EntityRow> {
+    Ok(EntityRow {
+        id: r.get(0)?,
+        file_path: r.get(1)?,
+        title: r.get(2)?,
+        layer: r.get(3)?,
+        status: r.get(4)?,
+        interest: r.get(5)?,
+        strategy: r.get(6)?,
+        consensus: r.get(7)?,
+        composite: r.get(8)?,
+        access_count: r.get(9)?,
+        last_boosted_at: r.get(10)?,
+        content_hash: r.get(11)?,
+        updated_at: r.get(12)?,
+    })
+}
+
+/// 内容指纹（DefaultHasher，固定种子，跨运行稳定；非加密，仅作变更检测）。
+fn content_hash(s: &str) -> String {
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    format!("{:016x}", h.finish())
+}
+
+/// 相对 vault 根的路径，统一正斜杠。
+fn rel_path(vault: &Path, p: &Path) -> String {
+    match p.strip_prefix(vault) {
+        Ok(rel) => rel.to_string_lossy().replace('\\', "/"),
+        Err(_) => p.to_string_lossy().replace('\\', "/"),
+    }
+}
+
+/// FTS MATCH 查询清洗：拆词、去引号、每词加双引号、AND 连接。
+fn fts_query(q: &str) -> String {
+    q.split_whitespace()
+        .map(|w| format!("\"{}\"", w.replace('"', "")))
+        .filter(|w| w != "\"\"")
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// 递归遍历 .md 文件，跳过隐藏目录/文件（.obsidian/.compass/.git 等）。
+fn walk_md(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    walk_md_inner(root, &mut out)?;
+    Ok(out)
+}
+
+fn walk_md_inner(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') {
+            continue;
+        }
+        if path.is_dir() {
+            walk_md_inner(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// 解析单个笔记 → EntityRow（+ 正文）。无 `id` 字段返回 None（跳过）。
+fn parse_entity(vault: &Path, path: &Path) -> Result<Option<(EntityRow, String)>> {
+    let note = frontmatter::read_note(path)?;
+    let fm: serde_yaml::Value =
+        serde_yaml::from_str(&note.frontmatter).context("解析 frontmatter 失败")?;
+    let m = fm
+        .as_mapping()
+        .ok_or_else(|| anyhow::anyhow!("frontmatter 不是 mapping"))?;
+
+    let id = match m
+        .get(serde_yaml::Value::String("id".into()))
+        .and_then(|v| v.as_str())
+    {
+        Some(s) => s.to_string(),
+        None => return Ok(None),
+    };
+
+    let get_str = |k: &str| {
+        m.get(serde_yaml::Value::String(k.into()))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    };
+
+    let score = frontmatter::get_score(&note.frontmatter)?;
+    let row = EntityRow {
+        id,
+        file_path: rel_path(vault, path),
+        title: get_str("title"),
+        layer: get_str("layer"),
+        status: get_str("status"),
+        interest: score.as_ref().map(|s| s.interest),
+        strategy: score.as_ref().map(|s| s.strategy),
+        consensus: score.as_ref().map(|s| s.consensus),
+        composite: score.as_ref().map(|s| s.composite),
+        access_count: score.as_ref().map(|s| s.access_count).unwrap_or(0),
+        last_boosted_at: score.as_ref().map(|s| s.last_boosted_at.clone()),
+        content_hash: Some(content_hash(&note.body)),
+        updated_at: score.as_ref().map(|s| s.updated_at.clone()),
+    };
+    Ok(Some((row, note.body)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn md_with_id(id: &str, title: &str, body: &str) -> String {
+        format!(
+            "---\n\
+             id: {id}\n\
+             title: {title}\n\
+             layer: knowledge\n\
+             status: active\n\
+             score:\n  interest: 85.0\n  strategy: 92.0\n  consensus: 78.0\n  composite: 85.3\n  updated_at: '2026-07-05T10:00:00+08:00'\n  last_boosted_at: '2026-07-05T10:00:00+08:00'\n  access_count: 12\n\
+             ---\n\
+             {body}\n"
+        )
+    }
+
+    fn md_without_id(title: &str) -> String {
+        format!("---\ntitle: {title}\n---\nbody text\n")
+    }
+
+    fn sample_row(id: &str) -> EntityRow {
+        EntityRow {
+            id: id.into(),
+            file_path: format!("{id}.md"),
+            title: Some("Game Theory".into()),
+            layer: Some("knowledge".into()),
+            status: Some("active".into()),
+            interest: Some(85.0),
+            strategy: Some(92.0),
+            consensus: Some(78.0),
+            composite: Some(85.3),
+            access_count: 12,
+            last_boosted_at: Some("2026-07-05T10:00:00+08:00".into()),
+            content_hash: Some("abc".into()),
+            updated_at: Some("2026-07-05T10:00:00+08:00".into()),
+        }
+    }
+
+    #[test]
+    fn test_open_in_memory_creates_schema() {
+        let db = Db::open_in_memory().unwrap();
+        // 表存在：插入查询不报错即证明
+        let row = sample_row("know-000001");
+        db.upsert_entity(&row, "body").unwrap();
+        let got = db.get_entity("know-000001").unwrap().unwrap();
+        assert_eq!(got.id, "know-000001");
+        assert_eq!(got.title.as_deref(), Some("Game Theory"));
+        assert!((got.composite.unwrap() - 85.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_open_creates_db_file_and_parent() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("nested").join("index.db");
+        {
+            let db = Db::open(&db_path).unwrap();
+            db.upsert_entity(&sample_row("know-1"), "b").unwrap();
+        }
+        assert!(db_path.exists(), "db 文件应被创建");
+    }
+
+    #[test]
+    fn test_upsert_then_get_roundtrip() {
+        let db = Db::open_in_memory().unwrap();
+        let row = sample_row("know-000001");
+        db.upsert_entity(&row, "Nash equilibrium is a core concept")
+            .unwrap();
+        let got = db.get_entity("know-000001").unwrap().unwrap();
+        assert_eq!(got, row);
+    }
+
+    #[test]
+    fn test_upsert_updates_existing() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "old body").unwrap();
+        let mut row = sample_row("know-1");
+        row.title = Some("Updated Title".into());
+        row.composite = Some(50.0);
+        db.upsert_entity(&row, "new body").unwrap();
+        let got = db.get_entity("know-1").unwrap().unwrap();
+        assert_eq!(got.title.as_deref(), Some("Updated Title"));
+        assert!((got.composite.unwrap() - 50.0).abs() < 1e-9);
+        // 实体不重复
+        assert_eq!(db.list_entities().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_list_entities_ordered_by_composite_desc() {
+        let db = Db::open_in_memory().unwrap();
+        let mut low = sample_row("know-low");
+        low.composite = Some(10.0);
+        let mut high = sample_row("know-high");
+        high.composite = Some(99.0);
+        db.upsert_entity(&low, "b").unwrap();
+        db.upsert_entity(&high, "b").unwrap();
+        let list = db.list_entities().unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].id, "know-high");
+        assert_eq!(list[1].id, "know-low");
+    }
+
+    #[test]
+    fn test_list_entities_null_composite_last() {
+        let db = Db::open_in_memory().unwrap();
+        let mut with_score = sample_row("know-1");
+        with_score.composite = Some(5.0);
+        let mut no_score = sample_row("know-2");
+        no_score.composite = None;
+        db.upsert_entity(&with_score, "b").unwrap();
+        db.upsert_entity(&no_score, "b").unwrap();
+        let list = db.list_entities().unwrap();
+        assert_eq!(list[0].id, "know-1");
+        assert_eq!(list[1].id, "know-2");
+    }
+
+    #[test]
+    fn test_fts_search_hit() {
+        let db = Db::open_in_memory().unwrap();
+        let row = sample_row("know-000001");
+        db.upsert_entity(&row, "Nash equilibrium is a core concept in game theory")
+            .unwrap();
+        let hits = db.fts_search("Nash", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "know-000001");
+        assert_eq!(hits[0].title.as_deref(), Some("Game Theory"));
+        assert!(hits[0].snippet.as_deref().unwrap_or("").contains("Nash"));
+    }
+
+    #[test]
+    fn test_fts_search_multi_word_and() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "Nash equilibrium game")
+            .unwrap();
+        db.upsert_entity(&sample_row("know-2"), "Nash only")
+            .unwrap();
+        let hits = db.fts_search("Nash equilibrium", 10).unwrap();
+        assert_eq!(hits.len(), 1, "多词应 AND，只命中含两词的");
+        assert_eq!(hits[0].id, "know-1");
+    }
+
+    #[test]
+    fn test_fts_search_no_match() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "hello world")
+            .unwrap();
+        let hits = db.fts_search("nonexistent", 10).unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_fts_search_empty_query_returns_empty() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "hello").unwrap();
+        assert!(db.fts_search("", 10).unwrap().is_empty());
+        assert!(db.fts_search("   ", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_fts_search_limit() {
+        let db = Db::open_in_memory().unwrap();
+        for i in 0..5 {
+            db.upsert_entity(&sample_row(&format!("know-{i}")), "common keyword")
+                .unwrap();
+        }
+        let hits = db.fts_search("common", 2).unwrap();
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn test_fts_update_reflects_new_content() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "old keyword alpha")
+            .unwrap();
+        assert_eq!(db.fts_search("alpha", 10).unwrap().len(), 1);
+        db.upsert_entity(&sample_row("know-1"), "new keyword beta")
+            .unwrap();
+        assert!(
+            db.fts_search("alpha", 10).unwrap().is_empty(),
+            "旧内容应被替换"
+        );
+        assert_eq!(db.fts_search("beta", 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_delete_entity_removes_fts() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-1"), "unique searchable text")
+            .unwrap();
+        assert_eq!(db.fts_search("unique", 10).unwrap().len(), 1);
+        db.delete_entity("know-1").unwrap();
+        assert!(db.get_entity("know-1").unwrap().is_none());
+        assert!(db.fts_search("unique", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_delete_nonexistent_is_noop() {
+        let db = Db::open_in_memory().unwrap();
+        db.delete_entity("ghost").unwrap();
+    }
+
+    #[test]
+    fn test_insert_and_get_score_history() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_score_history(&ScoreHistoryRow {
+            entity_id: "know-1".into(),
+            dimension: Some("interest".into()),
+            old: Some(80.0),
+            new: Some(82.0),
+            reason: Some("cited".into()),
+            trigger: Some("Cited".into()),
+            created_at: "2026-07-05T10:00:00Z".into(),
+        })
+        .unwrap();
+        let t = db.last_trigger_time("know-1", "Cited").unwrap();
+        assert_eq!(t.as_deref(), Some("2026-07-05T10:00:00Z"));
+    }
+
+    #[test]
+    fn test_last_trigger_time_returns_latest_by_insert_order() {
+        let db = Db::open_in_memory().unwrap();
+        // 故意让 created_at 字典序与插入序相反，验证按 id DESC（插入序）取最新
+        db.insert_score_history(&ScoreHistoryRow {
+            entity_id: "know-1".into(),
+            dimension: None,
+            old: None,
+            new: None,
+            reason: None,
+            trigger: Some("Cited".into()),
+            created_at: "2026-07-10T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.insert_score_history(&ScoreHistoryRow {
+            entity_id: "know-1".into(),
+            dimension: None,
+            old: None,
+            new: None,
+            reason: None,
+            trigger: Some("Cited".into()),
+            created_at: "2026-07-01T00:00:00Z".into(),
+        })
+        .unwrap();
+        let t = db.last_trigger_time("know-1", "Cited").unwrap();
+        // 插入序最新 = 第二条（id 更大），即使 created_at 更早
+        assert_eq!(t.as_deref(), Some("2026-07-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_last_trigger_time_none_when_no_record() {
+        let db = Db::open_in_memory().unwrap();
+        assert!(db.last_trigger_time("know-1", "Cited").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_last_trigger_time_filters_by_trigger_type() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_score_history(&ScoreHistoryRow {
+            entity_id: "know-1".into(),
+            dimension: None,
+            old: None,
+            new: None,
+            reason: None,
+            trigger: Some("Linked".into()),
+            created_at: "2026-07-09T00:00:00Z".into(),
+        })
+        .unwrap();
+        db.insert_score_history(&ScoreHistoryRow {
+            entity_id: "know-1".into(),
+            dimension: None,
+            old: None,
+            new: None,
+            reason: None,
+            trigger: Some("Cited".into()),
+            created_at: "2026-07-05T00:00:00Z".into(),
+        })
+        .unwrap();
+        let cited = db.last_trigger_time("know-1", "Cited").unwrap();
+        assert_eq!(cited.as_deref(), Some("2026-07-05T00:00:00Z"));
+        let linked = db.last_trigger_time("know-1", "Linked").unwrap();
+        assert_eq!(linked.as_deref(), Some("2026-07-09T00:00:00Z"));
+    }
+
+    #[test]
+    fn test_insert_timeline() {
+        let db = Db::open_in_memory().unwrap();
+        db.insert_timeline(&TimelineRow {
+            entity_id: "know-1".into(),
+            event_type: "access".into(),
+            intensity: Some(2.0),
+            source: Some("obsidian".into()),
+            created_at: "2026-07-05T10:00:00Z".into(),
+        })
+        .unwrap();
+        // 无直接查询接口，验证不报错即可（T1.5/T1.6 扩展查询）
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM timeline", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_rebuild_indexes_vault() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(
+            vault.join("know-000001.md"),
+            md_with_id("know-000001", "Game Theory", "Nash equilibrium is core."),
+        )
+        .unwrap();
+        fs::write(vault.join("noid.md"), md_without_id("No ID")).unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert_eq!(stats.indexed, 1, "有 id 的应被索引");
+        assert_eq!(stats.skipped, 1, "无 id 的应跳过");
+
+        let got = db.get_entity("know-000001").unwrap().unwrap();
+        assert_eq!(got.title.as_deref(), Some("Game Theory"));
+        assert_eq!(got.file_path, "know-000001.md");
+        assert!((got.composite.unwrap() - 85.3).abs() < 1e-9);
+        assert_eq!(got.access_count, 12);
+        assert!(got.content_hash.is_some());
+
+        // FTS 可查
+        let hits = db.fts_search("Nash", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "know-000001");
+    }
+
+    #[test]
+    fn test_rebuild_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(
+            vault.join("know-1.md"),
+            md_with_id("know-1", "A", "content one"),
+        )
+        .unwrap();
+        fs::write(
+            vault.join("know-2.md"),
+            md_with_id("know-2", "B", "content two"),
+        )
+        .unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        db.rebuild_from_vault(&vault).unwrap();
+        db.rebuild_from_vault(&vault).unwrap();
+        let list = db.list_entities().unwrap();
+        assert_eq!(list.len(), 2, "rebuild 两次不应重复");
+    }
+
+    #[test]
+    fn test_rebuild_duplicate_id_skipped() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(
+            vault.join("a.md"),
+            md_with_id("know-dup", "First", "first body alpha"),
+        )
+        .unwrap();
+        fs::write(
+            vault.join("b.md"),
+            md_with_id("know-dup", "Second", "second body beta"),
+        )
+        .unwrap();
+        let db = Db::open_in_memory().unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert_eq!(stats.indexed, 1, "首个索引，重复的跳过");
+        assert_eq!(stats.duplicates, 1, "重复 id 计数");
+        // 恰好一个被索引（不依赖 read_dir 顺序）
+        let hf = db.fts_search("alpha", 10).unwrap().len();
+        let hs = db.fts_search("beta", 10).unwrap().len();
+        assert_eq!(hf + hs, 1, "两个同 id 文件只索引一个");
+    }
+    #[test]
+    fn test_rebuild_skips_hidden_dirs() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        let obsidian = vault.join(".obsidian");
+        fs::create_dir_all(&obsidian).unwrap();
+        fs::write(
+            vault.join("know-1.md"),
+            md_with_id("know-1", "Visible", "visible body"),
+        )
+        .unwrap();
+        fs::write(
+            obsidian.join("config.md"),
+            md_with_id("hidden-1", "Hidden", "hidden body"),
+        )
+        .unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert_eq!(stats.indexed, 1);
+        assert!(db.get_entity("hidden-1").unwrap().is_none());
+        assert!(db.fts_search("hidden", 10).unwrap().is_empty());
+        assert!(db.fts_search("visible", 10).unwrap().len() == 1);
+    }
+
+    #[test]
+    fn test_rebuild_nested_subdirs() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        let nested = vault.join("Knowledge").join("Math");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(
+            nested.join("know-1.md"),
+            md_with_id("know-1", "Nested", "nested body"),
+        )
+        .unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        db.rebuild_from_vault(&vault).unwrap();
+        let got = db.get_entity("know-1").unwrap().unwrap();
+        assert_eq!(got.file_path, "Knowledge/Math/know-1.md");
+    }
+
+    #[test]
+    fn test_rebuild_real_vault_sample() {
+        // 对仓库内真实 vault 样本验证：compass-v2.md 有 id+score 应被索引
+        let vault = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("vault");
+        let vault = vault.canonicalize().unwrap();
+        let db = Db::open_in_memory().unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert!(stats.indexed >= 1, "至少索引 compass-v2.md");
+        let got = db.get_entity("proj-compass-v3").unwrap();
+        assert!(
+            got.is_some(),
+            "compass-v2.md 的 id=proj-compass-v3 应被索引"
+        );
+        let got = got.unwrap();
+        assert!((got.composite.unwrap() - 8.9).abs() < 1e-9);
+        assert_eq!(got.layer.as_deref(), Some("direction"));
+    }
+
+    #[test]
+    fn test_content_hash_stable() {
+        assert_eq!(content_hash("abc"), content_hash("abc"));
+        assert_ne!(content_hash("abc"), content_hash("abd"));
+    }
+
+    #[test]
+    fn test_fts_query_sanitizes() {
+        assert_eq!(fts_query("Nash equilibrium"), "\"Nash\" \"equilibrium\"");
+        assert_eq!(fts_query(""), "");
+        assert_eq!(fts_query("   "), "");
+        // 引号被剥离，避免注入 FTS 语法
+        assert_eq!(fts_query("\"inject"), "\"inject\"");
+    }
+}

--- a/docs/PRD_v3.0.md
+++ b/docs/PRD_v3.0.md
@@ -1,4 +1,4 @@
-﻿# Compass PRD v3.0 — 重做版精简规格
+# Compass PRD v3.0 — 重做版精简规格
 
 > 版本：v3.0 ｜ 日期：2026-07-05
 > 性质：实施规格（替代 `PRD_v2.1` 的臃肿路线）
@@ -122,7 +122,9 @@ PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;
 
 CREATE TABLE entities (               -- vault 文件的索引镜像
   id TEXT PRIMARY KEY, file_path TEXT UNIQUE, title TEXT,
-  layer TEXT, status TEXT, composite REAL,
+  layer TEXT, status TEXT,
+  interest REAL, strategy REAL, consensus REAL,  -- 三维缓存（frontmatter 权威；列表/feed 查询免读文件）
+  composite REAL,
   access_count INTEGER, last_boosted_at TEXT,
   content_hash TEXT, updated_at TEXT
 );

--- a/docs/REVIEW_T1.4.md
+++ b/docs/REVIEW_T1.4.md
@@ -1,0 +1,44 @@
+# T1.4 SQLite 索引层 — 独立 Review
+
+> 审阅对象：`compass-core/src/db.rs`（新）+ `config.rs`（加 `db_path`）
+> 依据：PRD_v3.0 §4.2 / PLAN T1.4 / 评分不变量 / T1.3 冷却接口
+> 模式：批判性自审（环境无 subagent），findings 在本分支修复后合并。
+
+## 验收对照（PLAN T1.4）
+
+| 验收项 | 证据 | 结论 |
+|--------|------|------|
+| entities/score_history/timeline/entities_fts 表 | `init_schema` 四表 + 索引；`test_open_in_memory_creates_schema` | ✅ |
+| 从 vault 全量重建索引 | `rebuild_from_vault` + `test_rebuild_indexes_vault`/`_is_idempotent`/`_nested`/`_real_vault_sample` | ✅ |
+| FTS5 可查 | `fts_search` + 7 个 fts 测试（命中/AND/无命中/空/limit/更新/删除） | ✅ |
+| cargo test 全绿 | 66 passed（原 40 + 新 26） | ✅ |
+
+## 不变量对照
+
+1. **frontmatter 权威**：rebuild 从 vault 解析 frontmatter 重建；SQLite 仅缓存。✅
+2. **删库可重建**：rebuild 清空 entities+fts 重建。⚠ score_history/timeline 不可从 vault 重建（PRD 设计：历史不进 frontmatter）——备份策略待 T1.5+。
+4. **写回不破坏正文**：T1.4 不写 frontmatter（仅读+索引），不涉及。✅
+
+## 接口对接
+
+- T1.3 `apply_trigger_if_eligible(last_for_type)` ← `Db::last_trigger_time(entity_id, trigger)`：按 `score_history.id DESC` 取最新（插入序=时间序，规避 RFC3339 时区排序歧义）。✅ 测试 `test_last_trigger_time_returns_latest_by_insert_order` 反向验证。
+
+## Findings
+
+| ID | 优先级 | 问题 | 处置 |
+|----|--------|------|------|
+| F1 | 中 | rebuild 遇重复 id 静默覆盖（最后胜出），数据完整性 | **修**：HashSet 检测 + warn + `duplicates` 统计，跳过后续 |
+| F2 | 中 | entities 加 interest/strategy/consensus 偏离 PRD §4.2 字面 | **修**：更新 PRD §4.2 注明缓存扩展 |
+| F3 | 低 | `unchecked_transaction` vs `transaction()` | **不修**：`transaction()` 需 `&mut self` 致 API 蔓延；`unchecked_transaction` 为 `&self` 无嵌套场景设计（clippy 不报），单连接顺序调用合理，保留 |
+| F4 | 低 | rebuild 每文件一事务，可批量 | 记录，T1.5 增量场景不阻塞 |
+| F5 | 低 | config db_path 解析无单测 | 记录 |
+| F6 | 前瞻 | Db 非 Sync，T1.6 axum 共享需 Mutex/pool | 记录，非 T1.4 阻塞 |
+
+## 安全
+
+- SQL 全参数化（`params!`），无拼接。✅
+- FTS `fts_query` 拆词去引号加双引号，防 FTS 语法注入（`-`/`*`/`OR`）。✅ 测试 `test_fts_query_sanitizes`。
+
+## 结论
+
+F1/F2/F3 修复后可合并。F4/F5/F6 记录后续。


### PR DESCRIPTION
## T1.4 SQLite 索引层

实现 `db.rs`：entities / score_history / timeline / entities_fts 四表 + CRUD + FTS5 + 从 vault 全量重建。

### 交付
- **schema**（PRD §4.2）：entities（+三维缓存列）/ score_history / timeline / entities_fts（FTS5 内部表，rowid 绑定 entities）/ 索引 / PRAGMA WAL+FK
- **CRUD**：`upsert_entity`（含 FTS 同步，事务）/ `get` / `delete`（清 FTS）/ `list`（composite DESC）
- **FTS5**：`fts_search`（snippet + rank），`fts_query` 拆词去引号防注入
- **冷却对接**：`last_trigger_time(entity_id, trigger)` 按 `id DESC` 取最新（插入序=时间序，规避 RFC3339 时区排序），供 T1.3 `apply_trigger_if_eligible`
- **rebuild_from_vault**：清空 entities+fts 重建，跳隐藏目录（.obsidian/.compass/.git），重复 id 检测（`duplicates` 统计），无 id 跳过
- **config**：加 `db_path`（缺省 `.compass/index.db`，相对配置目录解析）
- **PRD §4.2**：entities 注明三维缓存扩展

### 测试
67 passed（原 40 + 新 27）：FTS5 命中/AND/无命中/空/limit/更新/删除 + rebuild 索引/幂等/隐藏目录/嵌套/真实vault/重复id + 冷却历史(最新/无/按类型) + content_hash + fts_query 注入。

### Review（docs/REVIEW_T1.4.md，批判性自审）
- F1 重复 id 静默覆盖 → **已修**（HashSet 检测 + duplicates）
- F2 entities 三维列偏离 PRD 字面 → **已修**（更新 PRD §4.2）
- F3 `unchecked_transaction` vs `transaction()` → **不修**：`transaction()` 需 `&mut self` 致 API 蔓延；`unchecked_transaction` 为 `&self` 无嵌套场景设计（clippy 不报），单连接顺序调用合理
- F4 rebuild 批量事务 / F5 config db_path 单测 / F6 Db 非 Sync（T1.6 需 Mutex/pool）→ 记录后续

### 不变量
frontmatter 权威 ✓ ｜ 删库可重建 ✓（score_history 历史不可重建，PRD 设计，备份待 T1.5+）

验收：从 vault 全量重建索引 ✓ ｜ FTS5 可查 ✓