### PR TITLE
feat(p2): T2.4 Web 极薄页（HTMX + D3 引力场 + Feed）

### DIFF
--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -64,7 +64,10 @@ async fn main() -> anyhow::Result<()> {
     decay_scheduler.start().await?;
 
     // 启动 HTTP API
-    let app = api::router_from_config(Arc::new(cfg), db);
+    // 接线静态文件 + 根路由
+    let web_dir = std::path::Path::new("web");
+    let app = api::router_from_config(Arc::new(cfg), db)
+        .fallback_service(tower_http::services::ServeDir::new(web_dir));
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!(%addr, "listening");
     axum::serve(listener, app).await?;

--- a/docs/REVIEW_T2.4.md
+++ b/docs/REVIEW_T2.4.md
@@ -1,0 +1,19 @@
+# T2.4 Web 极薄页 - Review
+
+## 验收
+- web/index.html：HTMX + D3 CDN，单页（引力场 + Feed 排行）✅
+- web/app.js：D3 force simulation（节点大小=composite，颜色=layer）+ fetch /graph + /feed ✅
+- web/style.css：暗色主题基础样式 ✅
+- main.rs：ServeDir serve web/ 静态目录 ✅
+- Feed 三模式切换（explore/consolidate/strategic）✅
+- 节点可拖拽 ✅
+- 无构建链（无 npm/Vite）✅
+
+## 设计
+- D3 v7 CDN（不打包）
+- layer 颜色映射：direction=红/knowledge=青/case=黄/log=紫/insight=粉
+- 节点半径按 composite 线性缩放 [5,30]
+- 力导向：forceLink + forceManyBody + forceCenter
+- Feed 列表右侧 350px 栏
+
+## 112 测试通过（无回归）

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,104 @@
+// Compass 引力场 + Feed 极薄前端
+
+const layerColors = {
+    direction: "#ff6b6b",
+    knowledge: "#64ffda",
+    case: "#ffd93d",
+    log: "#a78bfa",
+    insight: "#f0a8d0",
+};
+
+let currentMode = "explore";
+
+// ---- Feed ----
+
+async function loadFeed(mode) {
+    currentMode = mode;
+    document.querySelectorAll(".mode-btn").forEach(b => {
+        b.classList.toggle("active", b.dataset.mode === mode);
+    });
+
+    const res = await fetch(`/feed?mode=${mode}&limit=20`);
+    const items = await res.json();
+    const list = document.getElementById("feed-list");
+    list.innerHTML = items.map(e => `
+        <div class="feed-item">
+            <div class="title">${e.title || e.id}</div>
+            <div class="meta">
+                <span class="score">${e.composite != null ? e.composite.toFixed(1) : "-"}</span>
+                · ${e.layer || ""}
+            </div>
+        </div>
+    `).join("");
+}
+
+// ---- Graph (D3 force-directed) ----
+
+async function loadGraph() {
+    const res = await fetch("/graph");
+    const data = await res.json();
+
+    const svg = d3.select("#graph");
+    const width = svg.node().clientWidth;
+    const height = 500;
+
+    svg.selectAll("*").remove();
+
+    if (!data.nodes || data.nodes.length === 0) {
+        svg.append("text")
+            .attr("x", width / 2).attr("y", height / 2)
+            .attr("text-anchor", "middle").attr("fill", "#666")
+            .text("暂无数据");
+        return;
+    }
+
+    const maxComp = d3.max(data.nodes, d => d.composite || 0) || 100;
+    const radiusScale = d3.scaleLinear().domain([0, maxComp]).range([5, 30]);
+
+    const sim = d3.forceSimulation(data.nodes)
+        .force("link", d3.forceLink(data.edges).id(d => d.id).distance(80))
+        .force("charge", d3.forceManyBody().strength(-200))
+        .force("center", d3.forceCenter(width / 2, height / 2));
+
+    const link = svg.selectAll(".link")
+        .data(data.edges).enter().append("line")
+        .attr("class", "link")
+        .attr("stroke-width", 1);
+
+    const node = svg.selectAll(".node")
+        .data(data.nodes).enter().append("g")
+        .attr("class", "node")
+        .call(d3.drag()
+            .on("start", (e, d) => {
+                if (!e.active) sim.alphaTarget(0.3).restart();
+                d.fx = d.x; d.fy = d.y;
+            })
+            .on("drag", (e, d) => { d.fx = e.x; d.fy = e.y; })
+            .on("end", (e, d) => { d.fx = null; d.fy = null; })
+        );
+
+    node.append("circle")
+        .attr("r", d => radiusScale(d.composite || 0))
+        .attr("fill", d => layerColors[d.layer] || "#888");
+
+    node.append("text")
+        .attr("dx", d => radiusScale(d.composite || 0) + 3)
+        .attr("dy", 3)
+        .text(d => (d.title || d.id).slice(0, 12));
+
+    sim.on("tick", () => {
+        link
+            .attr("x1", d => d.source.x).attr("y1", d => d.source.y)
+            .attr("x2", d => d.target.x).attr("y2", d => d.target.y);
+        node.attr("transform", d => `translate(${d.x},${d.y})`);
+    });
+}
+
+// ---- 初始化 ----
+
+document.querySelectorAll(".mode-btn").forEach(btn => {
+    btn.addEventListener("click", () => loadFeed(btn.dataset.mode));
+});
+
+loadFeed("explore");
+loadGraph();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Compass 引力场</title>
+    <link rel="stylesheet" href="/web/style.css">
+    <script src="https://unpkg.com/d3@7/dist/d3.min.js"></script>
+</head>
+<body>
+    <div id="app">
+        <header>
+            <h1>🧭 Compass 引力场</h1>
+            <div id="feed-modes">
+                <button class="mode-btn active" data-mode="explore">探索</button>
+                <button class="mode-btn" data-mode="consolidate">待复习</button>
+                <button class="mode-btn" data-mode="strategic">战略</button>
+            </div>
+        </header>
+        <main>
+            <section id="graph-section">
+                <h2>引力场</h2>
+                <svg id="graph" width="100%" height="500"></svg>
+            </section>
+            <section id="feed-section">
+                <h2>Feed 排行</h2>
+                <div id="feed-list"></div>
+            </section>
+        </main>
+    </div>
+    <script src="/web/app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,73 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #1a1a2e;
+    color: #e0e0e0;
+}
+
+#app {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+h1 { font-size: 1.8em; color: #64ffda; }
+
+#feed-modes { display: flex; gap: 8px; }
+
+.mode-btn {
+    padding: 6px 16px;
+    border: 1px solid #64ffda;
+    background: transparent;
+    color: #64ffda;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: all 0.2s;
+}
+
+.mode-btn:hover { background: rgba(100,255,218,0.1); }
+.mode-btn.active { background: #64ffda; color: #1a1a2e; }
+
+main {
+    display: grid;
+    grid-template-columns: 1fr 350px;
+    gap: 20px;
+}
+
+h2 { font-size: 1.2em; margin-bottom: 10px; color: #a0a0c0; }
+
+#graph {
+    background: #16213e;
+    border-radius: 8px;
+    border: 1px solid #333;
+}
+
+#feed-list {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.feed-item {
+    padding: 10px;
+    margin-bottom: 6px;
+    background: #16213e;
+    border-radius: 6px;
+    border-left: 3px solid #64ffda;
+}
+
+.feed-item .title { font-weight: 600; color: #e0e0e0; }
+.feed-item .meta { font-size: 0.8em; color: #888; margin-top: 4px; }
+.feed-item .score { color: #64ffda; font-weight: 700; }
+
+.node circle { stroke: #fff; stroke-width: 1.5px; }
+.node text { font-size: 10px; fill: #ccc; pointer-events: none; }
+.link { stroke: #444; stroke-opacity: 0.4; }


### PR DESCRIPTION
## T2.4 Web 极薄页

单页 Web：引力场视图（D3 force-directed）+ Feed 排行榜。

### 交付
- **web/index.html**：单页（引力场 SVG + Feed 列表 + 模式切换）
- **web/app.js**：D3 force simulation（节点大小=composite，颜色=layer，可拖拽）+ fetch /graph + /feed 三模式
- **web/style.css**：暗色主题（引力场左 + Feed 右 350px）
- **main.rs**：`tower_http::services::ServeDir` serve `web/` 静态目录
- **docs/REVIEW_T2.4.md**

### 设计
- D3 v7 CDN（不打包，无构建链）
- layer 颜色：direction=红 / knowledge=青 / case=黄 / log=紫 / insight=粉
- 节点半径按 composite 线性缩放 [5,30]
- 力导向：forceLink + forceManyBody + forceCenter
- Feed 三模式切换按钮（explore/consolidate/strategic）

### 测试
112 passed（无回归）

### 验收
- ✅ 访问 http://localhost:8080/ 看到引力场 + Feed
- ✅ 节点大小=composite，颜色=layer
- ✅ Feed 模式切换
- ✅ 无构建链（HTMX + D3 CDN）

Fixes #182