### PR TITLE
fix(p1): cargo clippy --all-targets -- -D warnings 修复

### DIFF
--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 use crate::config::Config;
 use crate::db::{Db, EntityRow};
 use crate::frontmatter;
-use crate::models::{Score, Weights};
+use crate::models::Weights;
 use crate::scoring;
 
 /// 共享应用状态
@@ -310,16 +310,6 @@ pub(crate) async fn create_entity(
     let consensus = req.consensus.unwrap_or(5.0);
     let composite = scoring::composite(interest, strategy, consensus, &state.weights);
     let now = chrono::Utc::now().to_rfc3339();
-    let score = Score {
-        interest,
-        strategy,
-        consensus,
-        composite,
-        weights: Some(state.weights.clone()),
-        updated_at: now.clone(),
-        last_boosted_at: now.clone(),
-        access_count: 0,
-    };
     let content = req.content.unwrap_or_default();
     let md = format!(
         "---\nid: {id}\ntitle: {}\nlayer: {}\nstatus: active\nscore:\n  interest: {interest}\n  strategy: {strategy}\n  consensus: {consensus}\n  composite: {composite}\n  weights:\n    interest: {}\n    strategy: {}\n    consensus: {}\n  updated_at: '{now}'\n  last_boosted_at: '{now}'\n  access_count: 0\n---\n{content}\n",
@@ -632,7 +622,7 @@ pub fn router_from_config(cfg: Arc<Config>, db: Arc<Mutex<Db>>) -> Router {
     let state = AppState {
         db,
         vault: cfg.vault_path.clone(),
-        weights: cfg.weights.clone(),
+        weights: cfg.weights,
     };
     router(state)
 }

--- a/compass-core/src/db.rs
+++ b/compass-core/src/db.rs
@@ -99,6 +99,7 @@ impl Db {
     }
 
     /// 内存数据库（测试用）。
+    #[cfg(test)]
     pub fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()?;
         let db = Self { conn };

--- a/compass-core/src/e2e_tests.rs
+++ b/compass-core/src/e2e_tests.rs
@@ -251,7 +251,7 @@ async fn test_e2e_search_after_create() {
     fs::create_dir_all(&vault).unwrap();
     let state = setup(&vault);
 
-    api::create_entity(
+    let _ = api::create_entity(
         axum::extract::State(state.clone()),
         axum::Json(CreateEntityRequest {
             title: "纳什均衡".to_string(),

--- a/compass-core/src/frontmatter.rs
+++ b/compass-core/src/frontmatter.rs
@@ -56,7 +56,7 @@ pub fn get_score(frontmatter: &str) -> Result<Option<Score>> {
     let Some(m) = fm.as_mapping() else {
         return Err(anyhow!("frontmatter 不是 mapping"));
     };
-    match m.get(&Value::String("score".into())) {
+    match m.get(Value::String("score".into())) {
         Some(v) => Ok(Some(
             serde_yaml::from_value(v.clone()).context("解析 score 块失败")?,
         )),
@@ -95,8 +95,7 @@ pub fn replace_score_block(frontmatter: &str, new_block: &str) -> String {
         Some(start_idx) => {
             // score 块结束 = 下一个顶层 key（非空且无前导空白）或文件尾
             let mut end_idx = lines.len();
-            for i in (start_idx + 1)..lines.len() {
-                let l = lines[i];
+            for (i, l) in lines.iter().enumerate().skip(start_idx + 1) {
                 if !l.is_empty() && !l.starts_with(' ') && !l.starts_with('\t') {
                     end_idx = i;
                     break;

--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 启动 FileWatcher
     let mut file_watcher =
-        watcher::FileWatcher::new(cfg.vault_path.clone(), db.clone(), cfg.weights.clone());
+        watcher::FileWatcher::new(cfg.vault_path.clone(), db.clone(), cfg.weights);
     file_watcher.start().await?;
     info!("FileWatcher started");
 
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     let decay_scheduler = DecayScheduler::new(
         db.clone(),
         cfg.vault_path.clone(),
-        cfg.weights.clone(),
+        cfg.weights,
         cfg.decay.clone(),
     );
     decay_scheduler.start().await?;

--- a/compass-core/src/models.rs
+++ b/compass-core/src/models.rs
@@ -32,17 +32,6 @@ impl Default for Weights {
     }
 }
 
-/// 实体层级（三大界）。
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Layer {
-    Direction,
-    Knowledge,
-    Case,
-    Log,
-    Insight,
-}
-
 /// frontmatter 中的 score 块（Compass 写回，Dataview 可读）。
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Score {

--- a/compass-core/src/watcher.rs
+++ b/compass-core/src/watcher.rs
@@ -77,7 +77,7 @@ impl FileWatcher {
         // 处理事件（去抖）
         let vault = self.vault.clone();
         let db = self.db.clone();
-        let weights = self.weights.clone();
+        let weights = self.weights;
 
         tokio::spawn(async move {
             let mut last_events: HashSet<PathBuf> = HashSet::new();
@@ -186,7 +186,7 @@ pub(crate) async fn process_single_file(
         Some(score) => {
             // 已有 score，重算 composite（确保一致性）
             let composite =
-                scoring::composite(score.interest, score.strategy, score.consensus, &weights);
+                scoring::composite(score.interest, score.strategy, score.consensus, weights);
             Score {
                 interest: score.interest,
                 strategy: score.strategy,
@@ -213,7 +213,7 @@ pub(crate) async fn process_single_file(
                 strategy: DEFAULT_STRATEGY,
                 consensus: DEFAULT_CONSENSUS,
                 composite,
-                weights: Some(weights.clone()),
+                weights: Some(*weights),
                 updated_at: now.clone(),
                 last_boosted_at: now,
                 access_count: 0,
@@ -388,7 +388,7 @@ fn extract_id_from_path(vault: &Path, path: &Path) -> Option<String> {
 fn extract_id_from_frontmatter(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("id".into()))
+    m.get(serde_yaml::Value::String("id".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -397,7 +397,7 @@ fn extract_id_from_frontmatter(frontmatter: &str) -> Option<String> {
 fn extract_title(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("title".into()))
+    m.get(serde_yaml::Value::String("title".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -406,7 +406,7 @@ fn extract_title(frontmatter: &str) -> Option<String> {
 fn extract_layer(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("layer".into()))
+    m.get(serde_yaml::Value::String("layer".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -415,7 +415,7 @@ fn extract_layer(frontmatter: &str) -> Option<String> {
 fn extract_status(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("status".into()))
+    m.get(serde_yaml::Value::String("status".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }


### PR DESCRIPTION
## 关联

Closes #189

## 变更

- `src/api.rs`：移除 `create_entity` 中未使用的 `Score` 变量与未使用导入；`router_from_config` 中 `Weights` 直接拷贝。
- `src/db.rs`：`open_in_memory` 标注 `#[cfg(test)]`。
- `src/models.rs`：移除未使用的 `Layer` enum（当前实现使用 `Option<String>` 存储 layer）。
- `src/frontmatter.rs`：消除 `needless_borrows_for_generic_args` 与 `needless_range_loop`。
- `src/watcher.rs`：`Weights` 为 `Copy`，移除多余 `clone`；消除 `needless_borrow`。
- `src/main.rs`：`Weights` 直接拷贝。
- `src/e2e_tests.rs`：绑定未使用的 `axum::Json` 返回值到 `_`。

## 验证

- [x] `cargo test --workspace`：117 passed
- [x] `cargo fmt --check`：通过
- [x] `cargo clippy --all-targets -- -D warnings`：通过
- [x] `cargo build --release`：通过
