### PR TITLE
fix(p1): cargo clippy --all-targets -- -D warnings 全绿

### DIFF
--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 use crate::config::Config;
 use crate::db::{Db, EntityRow};
 use crate::frontmatter;
-use crate::models::{Score, Weights};
+use crate::models::Weights;
 use crate::scoring;
 
 /// 共享应用状态
@@ -310,16 +310,6 @@ pub(crate) async fn create_entity(
     let consensus = req.consensus.unwrap_or(5.0);
     let composite = scoring::composite(interest, strategy, consensus, &state.weights);
     let now = chrono::Utc::now().to_rfc3339();
-    let score = Score {
-        interest,
-        strategy,
-        consensus,
-        composite,
-        weights: Some(state.weights.clone()),
-        updated_at: now.clone(),
-        last_boosted_at: now.clone(),
-        access_count: 0,
-    };
     let content = req.content.unwrap_or_default();
     let md = format!(
         "---\nid: {id}\ntitle: {}\nlayer: {}\nstatus: active\nscore:\n  interest: {interest}\n  strategy: {strategy}\n  consensus: {consensus}\n  composite: {composite}\n  weights:\n    interest: {}\n    strategy: {}\n    consensus: {}\n  updated_at: '{now}'\n  last_boosted_at: '{now}'\n  access_count: 0\n---\n{content}\n",
@@ -632,7 +622,7 @@ pub fn router_from_config(cfg: Arc<Config>, db: Arc<Mutex<Db>>) -> Router {
     let state = AppState {
         db,
         vault: cfg.vault_path.clone(),
-        weights: cfg.weights.clone(),
+        weights: cfg.weights,
     };
     router(state)
 }

--- a/compass-core/src/db.rs
+++ b/compass-core/src/db.rs
@@ -99,6 +99,7 @@ impl Db {
     }
 
     /// 内存数据库（测试用）。
+    #[cfg(test)]
     pub fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()?;
         let db = Self { conn };

--- a/compass-core/src/e2e_tests.rs
+++ b/compass-core/src/e2e_tests.rs
@@ -251,7 +251,7 @@ async fn test_e2e_search_after_create() {
     fs::create_dir_all(&vault).unwrap();
     let state = setup(&vault);
 
-    api::create_entity(
+    let _ = api::create_entity(
         axum::extract::State(state.clone()),
         axum::Json(CreateEntityRequest {
             title: "纳什均衡".to_string(),

--- a/compass-core/src/frontmatter.rs
+++ b/compass-core/src/frontmatter.rs
@@ -56,7 +56,7 @@ pub fn get_score(frontmatter: &str) -> Result<Option<Score>> {
     let Some(m) = fm.as_mapping() else {
         return Err(anyhow!("frontmatter 不是 mapping"));
     };
-    match m.get(&Value::String("score".into())) {
+    match m.get(Value::String("score".into())) {
         Some(v) => Ok(Some(
             serde_yaml::from_value(v.clone()).context("解析 score 块失败")?,
         )),
@@ -95,8 +95,7 @@ pub fn replace_score_block(frontmatter: &str, new_block: &str) -> String {
         Some(start_idx) => {
             // score 块结束 = 下一个顶层 key（非空且无前导空白）或文件尾
             let mut end_idx = lines.len();
-            for i in (start_idx + 1)..lines.len() {
-                let l = lines[i];
+            for (i, l) in lines.iter().enumerate().skip(start_idx + 1) {
                 if !l.is_empty() && !l.starts_with(' ') && !l.starts_with('\t') {
                     end_idx = i;
                     break;

--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 启动 FileWatcher
     let mut file_watcher =
-        watcher::FileWatcher::new(cfg.vault_path.clone(), db.clone(), cfg.weights.clone());
+        watcher::FileWatcher::new(cfg.vault_path.clone(), db.clone(), cfg.weights);
     file_watcher.start().await?;
     info!("FileWatcher started");
 
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     let decay_scheduler = DecayScheduler::new(
         db.clone(),
         cfg.vault_path.clone(),
-        cfg.weights.clone(),
+        cfg.weights,
         cfg.decay.clone(),
     );
     decay_scheduler.start().await?;

--- a/compass-core/src/models.rs
+++ b/compass-core/src/models.rs
@@ -35,6 +35,7 @@ impl Default for Weights {
 /// 实体层级（三大界）。
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[allow(dead_code)]
 pub enum Layer {
     Direction,
     Knowledge,

--- a/compass-core/src/watcher.rs
+++ b/compass-core/src/watcher.rs
@@ -77,7 +77,7 @@ impl FileWatcher {
         // 处理事件（去抖）
         let vault = self.vault.clone();
         let db = self.db.clone();
-        let weights = self.weights.clone();
+        let weights = self.weights;
 
         tokio::spawn(async move {
             let mut last_events: HashSet<PathBuf> = HashSet::new();
@@ -186,7 +186,7 @@ pub(crate) async fn process_single_file(
         Some(score) => {
             // 已有 score，重算 composite（确保一致性）
             let composite =
-                scoring::composite(score.interest, score.strategy, score.consensus, &weights);
+                scoring::composite(score.interest, score.strategy, score.consensus, weights);
             Score {
                 interest: score.interest,
                 strategy: score.strategy,
@@ -213,7 +213,7 @@ pub(crate) async fn process_single_file(
                 strategy: DEFAULT_STRATEGY,
                 consensus: DEFAULT_CONSENSUS,
                 composite,
-                weights: Some(weights.clone()),
+                weights: Some(*weights),
                 updated_at: now.clone(),
                 last_boosted_at: now,
                 access_count: 0,
@@ -388,7 +388,7 @@ fn extract_id_from_path(vault: &Path, path: &Path) -> Option<String> {
 fn extract_id_from_frontmatter(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("id".into()))
+    m.get(serde_yaml::Value::String("id".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -397,7 +397,7 @@ fn extract_id_from_frontmatter(frontmatter: &str) -> Option<String> {
 fn extract_title(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("title".into()))
+    m.get(serde_yaml::Value::String("title".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -406,7 +406,7 @@ fn extract_title(frontmatter: &str) -> Option<String> {
 fn extract_layer(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("layer".into()))
+    m.get(serde_yaml::Value::String("layer".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -415,7 +415,7 @@ fn extract_layer(frontmatter: &str) -> Option<String> {
 fn extract_status(frontmatter: &str) -> Option<String> {
     let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
     let m = fm.as_mapping()?;
-    m.get(&serde_yaml::Value::String("status".into()))
+    m.get(serde_yaml::Value::String("status".into()))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }


### PR DESCRIPTION
closes #189

`cargo clippy --all-targets -- -D warnings` 此前 16 error（合并的 #189 修复不完整）。本 PR 全绿。

## 改动（clippy --fix 自动 + 手动）

| 类别 | 修复 |
|---|---|
| clone-on-copy | `Weights`(Copy) 去 `.clone()`（api/main/watcher） |
| needless-borrow / needless-borrows-for-generic-args | `m.get(&Value::..)` -> `m.get(Value::..)`（frontmatter/watcher） |
| needless-range-loop | frontmatter `score_to_block` 改 iterator |
| dead_code | `open_in_memory` 加 `#[cfg(test)]`；`Layer` 加 `#[allow(dead_code)]` |
| unused-var | 移除 `create_entity` 死代码 `Score` 块（format! 已直接用各字段）+ 去 `Score` import |
| unused-must-use | e2e `create_entity` 丢弃返回值改 `let _ =` |

## 验证

- `cargo clippy --all-targets -- -D warnings`：**通过（0 error）**
- `cargo test`：**117 passed / 0 failed**
- `cargo fmt --check`：通过

纯机械修复，无逻辑变更；现有 117 测试全绿。