### PR TITLE
fix(p3): 对齐 search API 与 skill renderer 并补齐 E2E

### DIFF
--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -87,6 +87,8 @@ pub struct SearchHit {
     pub id: String,
     pub title: Option<String>,
     pub snippet: Option<String>,
+    pub layer: Option<String>,
+    pub composite: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -310,10 +312,21 @@ pub(crate) async fn search(
     let hits = db.fts_search(&q.q, q.limit)?;
     let results: Vec<SearchHit> = hits
         .into_iter()
-        .map(|h| SearchHit {
-            id: h.id,
-            title: h.title,
-            snippet: h.snippet,
+        .map(|h| {
+            // 补充 composite/layer 供 skill render 显示评分与分类
+            let (layer, composite) = db
+                .get_entity(&h.id)
+                .ok()
+                .flatten()
+                .map(|e| (e.layer, e.composite))
+                .unwrap_or((None, None));
+            SearchHit {
+                id: h.id,
+                title: h.title,
+                snippet: h.snippet,
+                layer,
+                composite,
+            }
         })
         .collect();
     Ok(Json(results))
@@ -1214,6 +1227,14 @@ mod tests {
         let r = search(State(state), Query(q)).await.unwrap().0;
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].id, "know000001");
+        assert_eq!(r[0].layer.as_deref(), Some("knowledge"));
+        assert!((r[0].composite.unwrap() - 80.0).abs() < 1e-9);
+        assert!(r[0]
+            .snippet
+            .as_deref()
+            .unwrap_or("")
+            .to_lowercase()
+            .contains("nash"));
     }
 
     #[tokio::test]

--- a/skills/compass/compass
+++ b/skills/compass/compass
@@ -55,7 +55,7 @@ def http_get(path: str, params: dict | None = None) -> dict:
         body = e.read().decode(errors="replace")
         try:
             err_body = json.loads(body)
-            print(json.dumps({"error": err_body.get("detail", body), "status": e.code}), file=sys.stderr)
+            print(json.dumps({"error": err_body.get("error", body), "status": e.code}), file=sys.stderr)
         except Exception:
             print(json.dumps({"error": body or e.reason, "status": e.code}), file=sys.stderr)
         sys.exit(1)
@@ -77,7 +77,7 @@ def http_patch(path: str, data: dict) -> dict:
         body = e.read().decode(errors="replace")
         try:
             err_body = json.loads(body)
-            print(json.dumps({"error": err_body.get("detail", body), "status": e.code}), file=sys.stderr)
+            print(json.dumps({"error": err_body.get("error", body), "status": e.code}), file=sys.stderr)
         except Exception:
             print(json.dumps({"error": body or e.reason, "status": e.code}), file=sys.stderr)
         sys.exit(1)
@@ -99,7 +99,7 @@ def http_post(path: str, data: dict) -> dict:
         body = e.read().decode(errors="replace")
         try:
             err_body = json.loads(body)
-            print(json.dumps({"error": err_body.get("detail", body), "status": e.code}), file=sys.stderr)
+            print(json.dumps({"error": err_body.get("error", body), "status": e.code}), file=sys.stderr)
         except Exception:
             print(json.dumps({"error": body or e.reason, "status": e.code}), file=sys.stderr)
         sys.exit(1)
@@ -205,79 +205,106 @@ def action_access(params: dict) -> None:
     print(json.dumps(result, indent=2))
 
 
-def _render_search(data: dict) -> str:
-    results = data.get("results", [])
+def _render_search(data) -> str:
+    # API 返回列表；旧格式也兼容 {results: [...]}
+    results = data if isinstance(data, list) else data.get("results", [])
     if not results:
         return "没有找到相关结果。"
-    lines = []
+    lines = ["## 搜索结果"]
     for i, ent in enumerate(results, 1):
-        score = ent.get("composite", 0)
-        title = ent.get("title", ent.get("id", "?"))
+        score = ent.get("composite", 0) or 0
+        title = ent.get("title") or ent.get("id", "?")
         eid = ent.get("id", "")
-        cat = ent.get("category", "")
-        lines.append(f"{i}. [{title}]({eid}) — ⭐{score:.1f}分  [{cat}]")
-    return "## 搜索结果\n" + "\n".join(lines)
+        layer = ent.get("layer", "")
+        snippet = ent.get("snippet", "")
+        line = f"{i}. [{title}]({eid}) — ⭐{score:.1f}分"
+        if layer:
+            line += f" [{layer}]"
+        if snippet:
+            line += f"\n   {snippet}"
+        lines.append(line)
+    return "\n".join(lines)
 
 
-def _render_top(data: dict) -> str:
-    results = data.get("results", [])
+def _render_top(data) -> str:
+    # API 返回列表；旧格式也兼容 {results: [...]}
+    results = data if isinstance(data, list) else data.get("results", [])
     if not results:
         return "没有找到结果。"
-    lines = []
+    lines = [f"## Top {len(results)}"]
     for i, ent in enumerate(results, 1):
-        score = ent.get("composite", 0)
-        title = ent.get("title", ent.get("id", "?"))
+        score = ent.get("composite", 0) or 0
+        title = ent.get("title") or ent.get("id", "?")
         eid = ent.get("id", "")
-        lines.append(f"{i}. [{title}]({eid}) — ⭐{score:.1f}分")
-    return "## Top " + str(len(results)) + "\n" + "\n".join(lines)
+        layer = ent.get("layer", "")
+        line = f"{i}. [{title}]({eid}) — ⭐{score:.1f}分"
+        if layer:
+            line += f" [{layer}]"
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def _render_get(data: dict) -> str:
     title = data.get("title", "?")
     eid = data.get("id", "?")
-    cat = data.get("category", "?")
-    scores = data.get("scores", {})
-    interest = scores.get("interest", 0)
-    strategy = scores.get("strategy", 0)
-    consensus = scores.get("consensus", 0)
-    final = data.get("composite", 0)
+    layer = data.get("layer", "?")
+    status = data.get("status", "")
+    # API 返回 score 对象（interest/strategy/consensus/composite/...）
+    score = data.get("score") or {}
+    interest = score.get("interest", 0) or 0
+    strategy = score.get("strategy", 0) or 0
+    consensus = score.get("consensus", 0) or 0
+    final = score.get("composite", data.get("composite", 0)) or 0
 
-    outgoing = data.get("outgoing_refs", [])
-    incoming = data.get("incoming_refs", [])
+    refs = data.get("refs", [])
 
-    parts = [f"## {title} ({eid})", f"分类：{cat}", f"⭐ 评分：{final:.1f}（interest {interest:.1f} / strategy {strategy:.1f} / consensus {consensus:.1f}）"]
+    parts = [f"## {title} ({eid})"]
+    if layer:
+        parts.append(f"分类：{layer}")
+    if status:
+        parts.append(f"状态：{status}")
+    parts.append(f"⭐ 评分：{final:.1f}（interest {interest:.1f} / strategy {strategy:.1f} / consensus {consensus:.1f}）")
 
-    if outgoing:
-        refs = ", ".join(f"[[{r}]]" for r in outgoing)
-        parts.append(f"→ 引用：{refs}")
-    if incoming:
-        refs = ", ".join(f"[[{r}]]" for r in incoming)
-        parts.append(f"← 被引用：{refs}")
+    if refs:
+        refs_str = ", ".join(f"[[{r}]]" for r in refs)
+        parts.append(f"→ 引用：{refs_str}")
 
     return "\n".join(parts)
 
 
-def _render_feed(data: dict) -> str:
+def _render_feed(data) -> str:
+    # API /feed 返回单一列表；旧格式也兼容 {top_inbox/recently_updated/strategic}
+    if isinstance(data, list):
+        top_inbox = data[:3]
+        recently_updated = []
+        strategic = []
+    else:
+        top_inbox = data.get("top_inbox", [])[:3]
+        recently_updated = data.get("recently_updated", [])[:3]
+        strategic = data.get("strategic", [])[:3]
+
     lines = ["**今日焦点**"]
-    for ent in data.get("top_inbox", [])[:3]:
-        title = ent.get("title", "?")
+    for ent in top_inbox:
+        title = ent.get("title") or ent.get("id", "?")
         eid = ent.get("id", "?")
-        score = ent.get("composite", 0)
+        score = ent.get("composite", 0) or 0
         lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
 
-    lines.append("**最近更新**")
-    for ent in data.get("recently_updated", [])[:3]:
-        title = ent.get("title", "?")
-        eid = ent.get("id", "?")
-        score = ent.get("composite", 0)
-        lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
+    if recently_updated:
+        lines.append("**最近更新**")
+        for ent in recently_updated:
+            title = ent.get("title") or ent.get("id", "?")
+            eid = ent.get("id", "?")
+            score = ent.get("composite", 0) or 0
+            lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
 
-    lines.append("**战略焦点**")
-    for ent in data.get("strategic", [])[:3]:
-        title = ent.get("title", "?")
-        eid = ent.get("id", "?")
-        score = ent.get("composite", 0)
-        lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
+    if strategic:
+        lines.append("**战略焦点**")
+        for ent in strategic:
+            title = ent.get("title") or ent.get("id", "?")
+            eid = ent.get("id", "?")
+            score = ent.get("composite", 0) or 0
+            lines.append(f"- [{title}]({eid}) — ⭐{score:.1f}")
 
     return "\n".join(lines)
 

--- a/skills/compass/test_compass.py
+++ b/skills/compass/test_compass.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Compass skill 自动化测试：覆盖 CLI render 与参数解析。
+
+运行：python3 test_compass.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+COMPASS_DIR = os.path.dirname(os.path.abspath(__file__))
+COMPASS_SCRIPT = os.path.join(COMPASS_DIR, "compass")
+
+
+def run(cmd):
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8"
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+class TestRenderCLI(unittest.TestCase):
+    def test_render_search_list(self):
+        raw = json.dumps(
+            [
+                {
+                    "id": "know000001",
+                    "title": "Nash Equilibrium",
+                    "snippet": "core concept",
+                    "layer": "knowledge",
+                    "composite": 85.7,
+                }
+            ]
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=search"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Nash Equilibrium", out)
+        self.assertIn("85.7", out)
+        self.assertIn("[knowledge]", out)
+        self.assertIn("core concept", out)
+
+    def test_render_search_empty(self):
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", "raw=[]", "action=search"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("没有找到", out)
+
+    def test_render_search_legacy_dict(self):
+        raw = json.dumps(
+            {
+                "results": [
+                    {"id": "know000001", "title": "Nash", "composite": 70.0, "layer": "case"}
+                ]
+            }
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=search"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Nash", out)
+        self.assertIn("70.0", out)
+
+    def test_render_top_list(self):
+        raw = json.dumps(
+            [{"id": "know000001", "title": "Nash", "layer": "knowledge", "composite": 85.7}]
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=top"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("## Top 1", out)
+        self.assertIn("85.7", out)
+
+    def test_render_top_empty(self):
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", "raw=[]", "action=top"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("没有找到", out)
+
+    def test_render_get(self):
+        raw = json.dumps(
+            {
+                "id": "know000001",
+                "title": "Nash Equilibrium",
+                "layer": "knowledge",
+                "status": "active",
+                "score": {
+                    "interest": 80.0,
+                    "strategy": 90.0,
+                    "consensus": 70.0,
+                    "composite": 81.0,
+                    "access_count": 5,
+                },
+                "refs": ["know000002"],
+            }
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=get"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Nash Equilibrium", out)
+        self.assertIn("knowledge", out)
+        self.assertIn("active", out)
+        self.assertIn("81.0", out)
+        self.assertIn("[[know000002]]", out)
+
+    def test_render_feed_list(self):
+        raw = json.dumps([{"id": "know000001", "title": "Nash", "composite": 85.7}])
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=feed"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("今日焦点", out)
+        self.assertIn("Nash", out)
+
+    def test_render_feed_dict(self):
+        raw = json.dumps(
+            {
+                "top_inbox": [{"id": "k1", "title": "A", "composite": 90.0}],
+                "recently_updated": [{"id": "k2", "title": "B", "composite": 80.0}],
+                "strategic": [{"id": "k3", "title": "C", "composite": 85.0}],
+            }
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=feed"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("今日焦点", out)
+        self.assertIn("最近更新", out)
+        self.assertIn("战略焦点", out)
+
+    def test_render_context(self):
+        raw = json.dumps(
+            {
+                "context": [
+                    {
+                        "id": "know000001",
+                        "title": "Nash",
+                        "content": "core concept",
+                        "composite": 85.7,
+                    }
+                ],
+                "reasoning": "recalled 1 entity",
+            }
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=context"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("Nash", out)
+        self.assertIn("core concept", out)
+        self.assertIn("recalled 1 entity", out)
+
+    def test_render_context_empty(self):
+        out, err, rc = run(
+            [
+                sys.executable,
+                COMPASS_SCRIPT,
+                "render",
+                'raw={"context": []}',
+                "action=context",
+            ]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("没有找到", out)
+
+    def test_render_create(self):
+        raw = json.dumps(
+            {"id": "know000002", "title": "New Note", "file_path": "Knowledge/know000002.md"}
+        )
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=create"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("已创建", out)
+        self.assertIn("New Note", out)
+
+    def test_render_score(self):
+        raw = json.dumps({"id": "know000001", "score": {"composite": 89.7}})
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=score"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("评分已更新", out)
+        self.assertIn("89.7", out)
+
+    def test_render_access(self):
+        raw = json.dumps({"id": "know000001", "score": {"composite": 91.7}})
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", f"raw={raw}", "action=access"]
+        )
+        self.assertEqual(rc, 0, f"stderr: {err}")
+        self.assertIn("访问已记录", out)
+        self.assertIn("91.7", out)
+
+    def test_render_unknown_action(self):
+        out, err, rc = run(
+            [sys.executable, COMPASS_SCRIPT, "render", 'raw={"id":"x"}', "action=unknown"]
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown action", err)
+
+    def test_render_invalid_json(self):
+        out, err, rc = run(
+            [
+                sys.executable,
+                COMPASS_SCRIPT,
+                "render",
+                "raw=not json",
+                "action=search",
+            ]
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("invalid JSON", err)
+
+    def test_render_from_stdin(self):
+        raw = json.dumps([{"id": "k1", "title": "T", "composite": 50.0}])
+        result = subprocess.run(
+            [sys.executable, COMPASS_SCRIPT, "render", "action=top"],
+            input=raw,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertIn("T", result.stdout)
+
+
+class TestCLI(unittest.TestCase):
+    def test_help_flag(self):
+        out, err, rc = run([sys.executable, COMPASS_SCRIPT, "--help"])
+        self.assertEqual(rc, 0)
+        self.assertIn("Usage", out)
+
+    def test_unknown_action(self):
+        out, err, rc = run([sys.executable, COMPASS_SCRIPT, "foobar"])
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown action", err)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/compass/test_e2e.py
+++ b/skills/compass/test_e2e.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Compass skill + compass-core HTTP API 端到端测试。
+
+运行前确保已在 compass-core 编译好二进制：
+    cd compass-core && cargo build --release
+
+运行：python3 test_e2e.py
+"""
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+COMPASS_DIR = os.path.dirname(os.path.abspath(__file__))
+COMPASS_SCRIPT = os.path.join(COMPASS_DIR, "compass")
+REPO_ROOT = os.path.dirname(os.path.dirname(COMPASS_DIR))
+COMPASS_CORE = os.path.join(REPO_ROOT, "compass-core")
+
+# Windows 上尽量使用编译后的二进制；否则 cargo run
+DEFAULT_BINARY = os.path.join(COMPASS_CORE, "target", "release", "compass.exe")
+if not os.path.exists(DEFAULT_BINARY):
+    DEFAULT_BINARY = os.path.join(COMPASS_CORE, "target", "debug", "compass.exe")
+
+
+def wait_for_server(url, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.2)
+    return False
+
+
+def compass_cli(*args, env=None):
+    """调用 skill CLI，返回 (stdout, stderr, rc)。"""
+    cmd = [sys.executable, COMPASS_SCRIPT] + list(args)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8", env=env
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+class TestE2ESkillAgainstApi(unittest.TestCase):
+    server_proc = None
+    tmpdir = None
+    env = None
+    vault = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="compass-e2e-")
+        vault = os.path.join(cls.tmpdir, "vault")
+        cls.vault = vault
+        os.makedirs(vault)
+
+        # 准备几个测试笔记
+        cls.note_a = os.path.join(vault, "know-000001.md")
+        with open(cls.note_a, "w", encoding="utf-8") as f:
+            f.write(
+                "---\n"
+                "id: know-000001\n"
+                "title: Nash Equilibrium\n"
+                "layer: knowledge\n"
+                "status: active\n"
+                "score:\n"
+                "  interest: 80.0\n"
+                "  strategy: 90.0\n"
+                "  consensus: 70.0\n"
+                "  composite: 81.0\n"
+                "  updated_at: '2026-07-09T00:00:00Z'\n"
+                "  last_boosted_at: '2026-07-09T00:00:00Z'\n"
+                "  access_count: 0\n"
+                "---\n"
+                "Nash equilibrium is a core concept in game theory.\n"
+            )
+
+        cls.note_b = os.path.join(vault, "dir-000001.md")
+        with open(cls.note_b, "w", encoding="utf-8") as f:
+            f.write(
+                "---\n"
+                "id: dir-000001\n"
+                "title: Strategic Direction\n"
+                "layer: direction\n"
+                "status: active\n"
+                "score:\n"
+                "  interest: 95.0\n"
+                "  strategy: 95.0\n"
+                "  consensus: 95.0\n"
+                "  composite: 95.0\n"
+                "  updated_at: '2026-07-09T00:00:00Z'\n"
+                "  last_boosted_at: '2026-07-09T00:00:00Z'\n"
+                "  access_count: 0\n"
+                "---\n"
+                "This direction guides all strategic decisions.\n"
+            )
+
+        # 临时配置（TOML 字符串用正斜杠避免反斜杠转义问题）
+        cfg_path = os.path.join(cls.tmpdir, "compass.toml")
+        vault_fwd = vault.replace("\\", "/")
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            f.write(
+                f'vault_path = "{vault_fwd}"\n'
+                "port = 18080\n"
+                "\n[weights]\n"
+                "interest = 0.40\n"
+                "strategy = 0.35\n"
+                "consensus = 0.25\n"
+                "\n[decay]\n"
+                "daily_rate = 0.98\n"
+                "floor = 0.5\n"
+                "boost_protection_days = 3\n"
+                "direction_layer_factor = 0.5\n"
+            )
+
+        cls.env = os.environ.copy()
+        cls.env["COMPASS_CONFIG"] = cfg_path
+        cls.env["COMPASS_API_URL"] = "http://localhost:18080"
+
+        # 启动服务器
+        if os.path.exists(DEFAULT_BINARY):
+            cmd = [DEFAULT_BINARY]
+            cls.server_cwd = COMPASS_CORE
+        else:
+            cmd = ["cargo", "run", "--quiet"]
+            cls.server_cwd = COMPASS_CORE
+
+        cls.server_proc = subprocess.Popen(
+            cmd,
+            cwd=cls.server_cwd,
+            env=cls.env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        )
+
+        if not wait_for_server("http://localhost:18080/health", timeout=60):
+            cls._kill_server()
+            raise RuntimeError("compass server failed to start")
+
+    def setUp(self):
+        self.created_files = []
+
+    def tearDown(self):
+        for path in self.created_files:
+            entity_id = os.path.splitext(os.path.basename(path))[0]
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                continue
+
+            # FileWatcher is asynchronous; wait until SQLite no longer exposes
+            # the entity before the next test starts.
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                try:
+                    with urllib.request.urlopen(
+                        f"http://localhost:18080/entities/{entity_id}", timeout=1
+                    ):
+                        pass
+                except urllib.error.HTTPError as exc:
+                    is_absent = exc.code == 404
+                    exc.close()
+                    if is_absent:
+                        break
+                except urllib.error.URLError:
+                    break
+                time.sleep(0.1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._kill_server()
+        if cls.tmpdir and os.path.exists(cls.tmpdir):
+            shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    @classmethod
+    def _kill_server(cls):
+        if cls.server_proc and cls.server_proc.poll() is None:
+            if sys.platform == "win32":
+                cls.server_proc.terminate()
+                try:
+                    cls.server_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    cls.server_proc.kill()
+            else:
+                cls.server_proc.send_signal(signal.SIGTERM)
+                try:
+                    cls.server_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    cls.server_proc.kill()
+
+    # ---- action + render 两阶段闭环 ----
+
+    def test_health(self):
+        out, err, rc = compass_cli("render", 'raw={"status":"ok"}', "action=create", env=self.env)
+        self.assertEqual(rc, 0)
+
+    def test_search_and_render(self):
+        raw, err, rc = compass_cli("search", "q=Nash", "limit=5", env=self.env)
+        self.assertEqual(rc, 0, f"search failed: {err}")
+        data = json.loads(raw)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["id"], "know-000001")
+        self.assertIn("composite", data[0])
+        self.assertIn("layer", data[0])
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=search", env=self.env
+        )
+        self.assertEqual(rc, 0, f"render failed: {err}")
+        self.assertIn("Nash Equilibrium", rendered)
+        self.assertIn("81.0", rendered)
+
+    def test_top_and_render(self):
+        raw, err, rc = compass_cli("top", "limit=5", env=self.env)
+        self.assertEqual(rc, 0, f"top failed: {err}")
+        data = json.loads(raw)
+        self.assertGreaterEqual(len(data), 2)
+        # 默认按 composite 降序，direction 95 应在第一
+        self.assertEqual(data[0]["id"], "dir-000001")
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=top", env=self.env
+        )
+        self.assertEqual(rc, 0, f"render failed: {err}")
+        self.assertIn("Strategic Direction", rendered)
+
+    def test_top_layer_filter(self):
+        raw, err, rc = compass_cli("top", "limit=5", "layer=knowledge", env=self.env)
+        self.assertEqual(rc, 0, f"top layer failed: {err}")
+        data = json.loads(raw)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["id"], "know-000001")
+
+    def test_get_and_render(self):
+        raw, err, rc = compass_cli("get", "id=know-000001", env=self.env)
+        self.assertEqual(rc, 0, f"get failed: {err}")
+        data = json.loads(raw)
+        self.assertEqual(data["id"], "know-000001")
+        self.assertEqual(data["score"]["composite"], 81.0)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=get", env=self.env
+        )
+        self.assertEqual(rc, 0, f"render failed: {err}")
+        self.assertIn("Nash Equilibrium", rendered)
+        self.assertIn("81.0", rendered)
+
+    def test_feed_and_render(self):
+        raw, err, rc = compass_cli("feed", "limit=5", env=self.env)
+        self.assertEqual(rc, 0, f"feed failed: {err}")
+        data = json.loads(raw)
+        self.assertGreaterEqual(len(data), 2)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=feed", env=self.env
+        )
+        self.assertEqual(rc, 0, f"render failed: {err}")
+        self.assertIn("今日焦点", rendered)
+
+    def test_context_and_render(self):
+        raw, err, rc = compass_cli(
+            "context", "task=game theory", "top_k=2", env=self.env
+        )
+        self.assertEqual(rc, 0, f"context failed: {err}")
+        data = json.loads(raw)
+        self.assertGreaterEqual(len(data["context"]), 1)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=context", env=self.env
+        )
+        self.assertEqual(rc, 0, f"render failed: {err}")
+        self.assertIn("Nash", rendered)
+
+    def test_create_and_score_and_access(self):
+        # create
+        raw, err, rc = compass_cli(
+            "create",
+            "title=Test Note",
+            "layer=knowledge",
+            "content=body content",
+            "interest=70",
+            "strategy=80",
+            "consensus=60",
+            env=self.env,
+        )
+        self.assertEqual(rc, 0, f"create failed: {err}")
+        data = json.loads(raw)
+        self.assertIn("id", data)
+        new_id = data["id"]
+        self.created_files.append(os.path.join(self.vault, data["file_path"]))
+        self.assertAlmostEqual(data["composite"], 71.0, places=6)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=create", env=self.env
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("Test Note", rendered)
+
+        # score
+        raw, err, rc = compass_cli(
+            "score", f"id={new_id}", "interest=95", env=self.env
+        )
+        self.assertEqual(rc, 0, f"score failed: {err}")
+        data = json.loads(raw)
+        self.assertAlmostEqual(data["score"]["composite"], 81.0, places=6)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=score", env=self.env
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("81.0", rendered)
+
+        # access
+        raw, err, rc = compass_cli(
+            "access", f"id={new_id}", "depth=study", env=self.env
+        )
+        self.assertEqual(rc, 0, f"access failed: {err}")
+        data = json.loads(raw)
+        self.assertAlmostEqual(data["score"]["interest"], 98.0, places=6)
+        self.assertEqual(data["score"]["access_count"], 1)
+
+        rendered, err, rc = compass_cli(
+            "render", f"raw={raw}", "action=access", env=self.env
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("访问已记录", rendered)
+
+    def test_get_not_found(self):
+        out, err, rc = compass_cli("get", "id=nonexistent", env=self.env)
+        self.assertEqual(rc, 1)
+        self.assertIn("not found", err.lower())
+
+    def test_search_no_match(self):
+        raw, err, rc = compass_cli("search", "q=xyzabc123", env=self.env)
+        self.assertEqual(rc, 0)
+        data = json.loads(raw)
+        self.assertEqual(data, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
﻿closes #195

## 变更

- Rust `/search` 响应补充 `layer`、`composite`，使 skill 可以展示分类与评分。
- skill renderer 对齐当前 Rust API：
  - search/top/feed 支持列表响应，并兼容旧 `{results: [...]}`；
  - get 读取嵌套 `score` 和 `refs`；
  - HTTP 错误读取 Rust 的 `error` 字段；
  - 保持 score/access/create/context 的现有渲染。
- 新增 skill renderer 单测 `test_compass.py`。
- 新增 HTTP E2E `test_e2e.py`，覆盖：
  - search/top/get/feed/context
  - create/score/access
  - 每个测试清理自己创建的实体并等待 FileWatcher 完成删除，避免测试顺序污染。

## 验证

- `cargo test --workspace`：119 passed / 0 failed
- `cargo clippy --all-targets -- -D warnings`：通过
- `cargo fmt --check`：通过
- `python -m unittest test_compass.py`：18 passed
- `python -m unittest test_e2e.py`：10 passed
- `python -m py_compile compass test_compass.py test_e2e.py`：通过

## 明确不包含

- `vault/Projects/compass-v2.md` 的运行时评分变化未提交，保留在本地工作区单独处理。
- `db.rs` 中因当前 vault 数据变化而产生的测试期望变化未提交。
- 临时 `.tmp_e2e`、raw JSON、空 TOML 已清理。
