### PR TITLE
docs: 更新 Phase 状态与验收说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,15 @@ Compass/
 - [x] T1.7 验收测试（端到端闭环）
 - [x] T1.8 文档与样例（Templater 模板 + README）
 
-### Phase 2 · 浮现与可视化（待开发）
+### Phase 2 · 浮现与可视化 ✅
 
-衰减调度 + Feed 三模式 + 引力场 Web（HTMX+D3）
+衰减调度 + Feed 三模式 + 引力场 Web（HTMX+D3）已完成。
 
-### Phase 3 · Agent/Skill 对接（待开发）
+### Phase 3 · Agent/Skill 对接 ✅
 
-适配 skill 脚本 + 全链路验收
+已完成 skill 脚本适配、`POST /agent/context`、search 响应对齐及本地全链路验收。
+
+验收路径：`skill action → Rust HTTP API → vault/frontmatter → FileWatcher → skill render`。
 
 ## 测试
 
@@ -183,7 +185,15 @@ cd compass-core
 cargo test
 ```
 
-115 个测试覆盖：评分引擎 / frontmatter 读写 / SQLite 索引 / FTS5 / FileWatcher / API 7 端点 / 端到端闭环。
+119 个 Rust 测试覆盖：评分引擎 / frontmatter 读写 / SQLite 索引 / FTS5 / FileWatcher / API / 端到端闭环。
+
+skill 侧另有 18 个 renderer 单测和 10 个 HTTP E2E：
+
+```bash
+cd skills/compass
+python -m unittest test_compass.py
+python -m unittest test_e2e.py
+```
 
 ## License
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -10,9 +10,9 @@
 
 | Phase | 名称 | 周期 | 状态 | 验收闭环 |
 |-------|------|------|------|----------|
-| 1 | 核心闭环 | 2-3 周 | 待开发 | Obsidian 新建笔记→引擎算分写回 frontmatter→Dataview 排序可见 |
+| 1 | 核心闭环 | 2-3 周 | ✅ 完成 | Obsidian 新建笔记→引擎算分写回 frontmatter→Dataview 排序可见 |
 | 2 | 浮现与可视化 | 2 周 | ✅ 完成 | `/feed` 浮现正确；Web 引力场节点大小=评分 |
-| 3 | Agent/Skill 对接 | 1-2 周 | 待开发 | 飞书"记一下 X"→vault 新增 .md；"今天有什么"→feed 卡片 |
+| 3 | Agent/Skill 对接 | 1-2 周 | ✅ 完成 | skill action→Compass API→vault；本地 E2E 覆盖 action + render + FileWatcher |
 | 4 | 智能增强 | 按需 | 待开发 | 自动标签/关联推荐/周报 |
 | 5 | 打磨 | 按需 | 待开发 | Dataview 模板库 + Git 备份 + 跨端同步 |
 
@@ -94,12 +94,12 @@
 
 ---
 
-## 6. 立即下一步
+## 6. 当前状态与下一步
 
-**启动 Phase 1 · T1.1 项目骨架**：
-1. 创建 `compass-core/` Cargo workspace（复用目录名，清空旧 Rust 代码）
-2. `Cargo.toml` 引入：axum、rusqlite(bundled)、notify、serde、serde_yaml、chrono、regex、tokio、tower-http
-3. `compass.toml` 配置骨架（vault_path、port=8080、decay 参数）
-4. axum `/health` 端点
+Phase 1、Phase 2、Phase 3 已完成。Phase 3 的本地验收从 `skills/compass` 开始，覆盖：
 
-> 待你确认即可开工。
+`skill action → Rust HTTP API → frontmatter/SQLite → FileWatcher → skill render`
+
+证据：`skills/compass/test_e2e.py`（10 个 E2E）和 `skills/compass/test_compass.py`（18 个 renderer 单测）。
+
+下一步为按需进入 Phase 4 智能增强；当前不启动自动标签、关联推荐或周报等非核心功能。


### PR DESCRIPTION
﻿closes #197

更新 `docs/PLAN.md` 和 `README.md`：

- Phase 1/2/3 状态改为已完成。
- 记录 Phase 3 本地验收链路：skill action -> Rust HTTP API -> frontmatter/SQLite -> FileWatcher -> skill render。
- 测试说明更新为 119 个 Rust 测试、18 个 renderer 单测、10 个 HTTP E2E。
- “立即下一步”改为按需进入 Phase 4，移除过期的 T1.1 启动指引。

不修改历史 PRD 文档。
