### PR TITLE
docs: 同步 T3.3 E2E 验收数量

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ cargo test
 
 119 个 Rust 测试覆盖：评分引擎 / frontmatter 读写 / SQLite 索引 / FTS5 / FileWatcher / API / 端到端闭环。
 
-skill 侧另有 18 个 renderer 单测和 10 个 HTTP E2E：
+skill 侧另有 18 个 renderer 单测和 14 个 HTTP E2E：
 
 ```bash
 cd skills/compass

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -100,6 +100,6 @@ Phase 1、Phase 2、Phase 3 已完成。Phase 3 的本地验收从 `skills/compa
 
 `skill action → Rust HTTP API → frontmatter/SQLite → FileWatcher → skill render`
 
-证据：`skills/compass/test_e2e.py`（10 个 E2E）和 `skills/compass/test_compass.py`（18 个 renderer 单测）。
+证据：`skills/compass/test_e2e.py`（14 个 E2E）和 `skills/compass/test_compass.py`（18 个 renderer 单测）。
 
 下一步为按需进入 Phase 4 智能增强；当前不启动自动标签、关联推荐或周报等非核心功能。


### PR DESCRIPTION
﻿closes #201

PR #200 后 T3.3 本地全链路 E2E 从 10 个扩展为 14 个；同步 README 和 PLAN 的验收证据数量。

不改变路线图或代码范围。
