### PR TITLE
fix(security): bind Compass locally by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ cargo build --release
 
 ```toml
 vault_path = "../vault"      # Obsidian vault 路径（相对配置文件）
+bind = "127.0.0.1"           # 默认仅本机访问
 port = 8080                  # HTTP API 端口
+allow_non_local = false      # 非本机监听必须显式改为 true
+# auth_token = "replace-with-a-secret"  # 配置后需 Authorization: Bearer <token>
+request_body_limit_bytes = 1048576
 
 [weights]                    # 三维默认权重（sum=1.0）
 interest = 0.40
@@ -70,6 +74,10 @@ cargo run --release
 - 自动从 vault 全量重建索引
 - FileWatcher 监听 vault 变更（新建/修改/删除）
 - HTTP API 监听 `http://localhost:8080`
+
+默认只监听本机回环地址。若需局域网或其他非本机访问，必须显式设置 `bind` 和
+`allow_non_local = true`；建议同时配置 `auth_token`，否则任何可达客户端都能读取
+Vault 内容并调用已有写接口。所有 JSON 请求默认限制为 1 MiB。
 
 ## API 端点
 

--- a/compass-core/Cargo.lock
+++ b/compass-core/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/compass-core/Cargo.toml
+++ b/compass-core/Cargo.toml
@@ -23,3 +23,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"
+tower = { version = "0.5", features = ["util"] }

--- a/compass-core/Cargo.toml
+++ b/compass-core/Cargo.toml
@@ -15,7 +15,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 notify = "6"
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
-tower-http = { version = "0.5", features = ["fs", "cors"] }
+tower-http = { version = "0.5", features = ["fs", "cors", "limit"] }
 anyhow = "1"
 fs2 = "0.4"
 tracing = "0.1"

--- a/compass-core/compass.toml
+++ b/compass-core/compass.toml
@@ -1,7 +1,11 @@
 ﻿# Compass 运行时配置
 # vault_path 相对本文件所在目录解析
 vault_path = "../vault"
+bind = "127.0.0.1"       # 默认仅本机访问；非本机监听需同时设置 allow_non_local = true
 port = 8080
+allow_non_local = false
+# auth_token = "replace-with-a-secret"  # 配置后所有 HTTP 请求需带 Authorization: Bearer <token>
+request_body_limit_bytes = 1048576
 
 [weights]            # 三维默认权重（sum=1.0）
 interest = 0.40

--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -6,9 +6,10 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::extract::{DefaultBodyLimit, Path, Query, Request, State};
+use axum::http::{header::AUTHORIZATION, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
@@ -708,13 +709,56 @@ pub fn router_from_config(cfg: Arc<Config>, db: Arc<Mutex<Db>>) -> Router {
         weights: cfg.weights,
     };
     router(state)
+        .layer(DefaultBodyLimit::max(cfg.request_body_limit_bytes))
+        .layer(middleware::from_fn_with_state(
+            cfg.auth_token.clone(),
+            require_auth,
+        ))
+}
+
+async fn require_auth(
+    State(expected): State<Option<String>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let authorized = expected.as_deref().is_none_or(|expected| {
+        request
+            .headers()
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .is_some_and(|provided| constant_time_eq(provided.as_bytes(), expected.as_bytes()))
+    });
+
+    if !authorized {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "authentication required"})),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
     use std::fs;
     use tempfile::tempdir;
+    use tower::ServiceExt;
 
     fn setup_state(vault: &std::path::Path) -> AppState {
         AppState {
@@ -746,6 +790,75 @@ mod tests {
             content_hash: Some("abc".to_string()),
             updated_at: Some("2026-07-09T00:00:00Z".to_string()),
         }
+    }
+
+    fn test_config(vault: &std::path::Path, auth_token: Option<&str>, limit: usize) -> Config {
+        Config {
+            vault_path: vault.to_path_buf(),
+            bind: "127.0.0.1".to_string(),
+            port: 8080,
+            allow_non_local: false,
+            auth_token: auth_token.map(str::to_string),
+            request_body_limit_bytes: limit,
+            db_path: None,
+            decay: crate::config::DecayConfig::default(),
+            weights: Weights::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_authentication_middleware() {
+        let dir = tempdir().unwrap();
+        let cfg = Arc::new(test_config(dir.path(), Some("test-secret"), 1024));
+        let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
+        let app = router_from_config(cfg, db);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .header("authorization", "Bearer test-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_http_request_body_limit() {
+        let dir = tempdir().unwrap();
+        let cfg = Arc::new(test_config(dir.path(), None, 64));
+        let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
+        let app = router_from_config(cfg, db);
+        let body =
+            r#"{"title":"a note whose request is intentionally too large","content":"body"}"#;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/entities")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[test]

--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::extract::{DefaultBodyLimit, Path, Query, Request, State};
+use axum::extract::{Path, Query, Request, State};
 use axum::http::{header::AUTHORIZATION, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
@@ -709,7 +709,13 @@ pub fn router_from_config(cfg: Arc<Config>, db: Arc<Mutex<Db>>) -> Router {
         weights: cfg.weights,
     };
     router(state)
-        .layer(DefaultBodyLimit::max(cfg.request_body_limit_bytes))
+}
+
+pub fn apply_security(router: Router, cfg: &Config) -> Router {
+    router
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(
+            cfg.request_body_limit_bytes,
+        ))
         .layer(middleware::from_fn_with_state(
             cfg.auth_token.clone(),
             require_auth,
@@ -809,9 +815,16 @@ mod tests {
     #[tokio::test]
     async fn test_http_authentication_middleware() {
         let dir = tempdir().unwrap();
+        let web_dir = dir.path().join("web");
+        fs::create_dir_all(&web_dir).unwrap();
+        fs::write(web_dir.join("index.html"), "private static content").unwrap();
         let cfg = Arc::new(test_config(dir.path(), Some("test-secret"), 1024));
         let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
-        let app = router_from_config(cfg, db);
+        let app = apply_security(
+            router_from_config(Arc::clone(&cfg), db)
+                .fallback_service(tower_http::services::ServeDir::new(web_dir)),
+            &cfg,
+        );
 
         let response = app
             .clone()
@@ -824,6 +837,43 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/index.html")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/missing")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/index.html")
+                    .header("authorization", "Bearer test-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
         let response = app
             .oneshot(
@@ -843,7 +893,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let cfg = Arc::new(test_config(dir.path(), None, 64));
         let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
-        let app = router_from_config(cfg, db);
+        let app = apply_security(router_from_config(cfg.clone(), db), &cfg);
         let body =
             r#"{"title":"a note whose request is intentionally too large","content":"body"}"#;
 

--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -713,12 +713,12 @@ pub fn router_from_config(cfg: Arc<Config>, db: Arc<Mutex<Db>>) -> Router {
 
 pub fn apply_security(router: Router, cfg: &Config) -> Router {
     router
-        .layer(tower_http::limit::RequestBodyLimitLayer::new(
-            cfg.request_body_limit_bytes,
-        ))
         .layer(middleware::from_fn_with_state(
             cfg.auth_token.clone(),
             require_auth,
+        ))
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(
+            cfg.request_body_limit_bytes,
         ))
 }
 
@@ -891,7 +891,7 @@ mod tests {
     #[tokio::test]
     async fn test_http_request_body_limit() {
         let dir = tempdir().unwrap();
-        let cfg = Arc::new(test_config(dir.path(), None, 64));
+        let cfg = Arc::new(test_config(dir.path(), Some("test-secret"), 64));
         let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
         let app = apply_security(router_from_config(cfg.clone(), db), &cfg);
         let body =
@@ -903,6 +903,7 @@ mod tests {
                     .method("POST")
                     .uri("/entities")
                     .header("content-type", "application/json")
+                    .header("content-length", body.len())
                     .body(Body::from(body))
                     .unwrap(),
             )

--- a/compass-core/src/config.rs
+++ b/compass-core/src/config.rs
@@ -7,8 +7,16 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub vault_path: PathBuf,
+    #[serde(default = "default_bind")]
+    pub bind: String,
     #[serde(default = "default_port")]
     pub port: u16,
+    #[serde(default)]
+    pub allow_non_local: bool,
+    #[serde(default)]
+    pub auth_token: Option<String>,
+    #[serde(default = "default_request_body_limit_bytes")]
+    pub request_body_limit_bytes: usize,
     /// SQLite 索引库路径。相对配置文件目录解析；缺省 `.compass/index.db`。
     #[serde(default)]
     pub db_path: Option<PathBuf>,
@@ -32,6 +40,12 @@ pub struct DecayConfig {
 
 fn default_port() -> u16 {
     8080
+}
+fn default_bind() -> String {
+    "127.0.0.1".to_string()
+}
+fn default_request_body_limit_bytes() -> usize {
+    1024 * 1024
 }
 fn default_rate() -> f64 {
     0.98
@@ -71,6 +85,8 @@ impl Config {
             toml::from_str(&raw).map_err(|e| anyhow::anyhow!("解析配置失败: {e}"))?;
 
         // F3: 校验权重归一化
+        cfg.validate_server_settings()?;
+
         if !cfg.weights.is_normalized() {
             return Err(anyhow::anyhow!(
                 "weights 归一化错误：和为 {}，应为 1.0（检查 compass.toml [weights]）",
@@ -110,5 +126,86 @@ impl Config {
         cfg.db_path = Some(db_path);
 
         Ok(cfg)
+    }
+
+    fn validate_server_settings(&self) -> anyhow::Result<()> {
+        if self.bind.trim().is_empty() {
+            return Err(anyhow::anyhow!("bind cannot be empty"));
+        }
+        if self.request_body_limit_bytes == 0 {
+            return Err(anyhow::anyhow!(
+                "request_body_limit_bytes must be greater than zero"
+            ));
+        }
+        if self.auth_token.as_deref().is_some_and(str::is_empty) {
+            return Err(anyhow::anyhow!("auth_token cannot be empty"));
+        }
+        if !is_local_bind(&self.bind) && !self.allow_non_local {
+            return Err(anyhow::anyhow!(
+                "non-local bind ({}) requires allow_non_local = true",
+                self.bind
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn is_local_bind(bind: &str) -> bool {
+    bind.eq_ignore_ascii_case("localhost")
+        || bind
+            .parse::<std::net::IpAddr>()
+            .map(|addr| addr.is_loopback())
+            .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(bind: &str, allow_non_local: bool) -> Config {
+        Config {
+            vault_path: PathBuf::from("vault"),
+            bind: bind.to_string(),
+            port: 8080,
+            allow_non_local,
+            auth_token: None,
+            request_body_limit_bytes: default_request_body_limit_bytes(),
+            db_path: None,
+            decay: DecayConfig::default(),
+            weights: Weights::default(),
+        }
+    }
+
+    #[test]
+    fn default_server_settings_are_local_only() {
+        assert_eq!(default_bind(), "127.0.0.1");
+        assert!(is_local_bind("127.0.0.1"));
+        assert!(is_local_bind("::1"));
+        assert!(is_local_bind("localhost"));
+        assert!(!is_local_bind("0.0.0.0"));
+        assert_eq!(default_request_body_limit_bytes(), 1024 * 1024);
+        assert!(config("127.0.0.1", false)
+            .validate_server_settings()
+            .is_ok());
+    }
+
+    #[test]
+    fn non_local_bind_requires_explicit_opt_in() {
+        let invalid = config("0.0.0.0", false);
+        let error = invalid.validate_server_settings().unwrap_err().to_string();
+        assert!(error.contains("allow_non_local"));
+
+        assert!(config("0.0.0.0", true).validate_server_settings().is_ok());
+    }
+
+    #[test]
+    fn invalid_server_settings_are_rejected() {
+        let mut config = config("127.0.0.1", false);
+        config.request_body_limit_bytes = 0;
+        assert!(config.validate_server_settings().is_err());
+
+        config.request_body_limit_bytes = default_request_body_limit_bytes();
+        config.auth_token = Some(String::new());
+        assert!(config.validate_server_settings().is_err());
     }
 }

--- a/compass-core/src/config.rs
+++ b/compass-core/src/config.rs
@@ -151,11 +151,27 @@ impl Config {
 }
 
 fn is_local_bind(bind: &str) -> bool {
+    let bind = bind
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(bind);
     bind.eq_ignore_ascii_case("localhost")
         || bind
             .parse::<std::net::IpAddr>()
             .map(|addr| addr.is_loopback())
             .unwrap_or(false)
+}
+
+pub(crate) fn format_bind_address(bind: &str, port: u16) -> String {
+    let host = bind
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(bind);
+    if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
 }
 
 #[cfg(test)]
@@ -181,12 +197,27 @@ mod tests {
         assert_eq!(default_bind(), "127.0.0.1");
         assert!(is_local_bind("127.0.0.1"));
         assert!(is_local_bind("::1"));
+        assert!(is_local_bind("[::1]"));
         assert!(is_local_bind("localhost"));
         assert!(!is_local_bind("0.0.0.0"));
         assert_eq!(default_request_body_limit_bytes(), 1024 * 1024);
+        assert_eq!(format_bind_address("127.0.0.1", 8080), "127.0.0.1:8080");
+        assert_eq!(format_bind_address("::1", 8080), "[::1]:8080");
+        assert_eq!(format_bind_address("[::1]", 8080), "[::1]:8080");
         assert!(config("127.0.0.1", false)
             .validate_server_settings()
             .is_ok());
+    }
+
+    #[test]
+    fn legacy_config_gets_secure_server_defaults() {
+        let config: Config = toml::from_str("vault_path = \"vault\"").unwrap();
+
+        assert_eq!(config.bind, "127.0.0.1");
+        assert!(!config.allow_non_local);
+        assert!(config.auth_token.is_none());
+        assert_eq!(config.request_body_limit_bytes, 1024 * 1024);
+        assert!(config.validate_server_settings().is_ok());
     }
 
     #[test]

--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cfg = config::Config::load()?;
-    let addr = format!("{}:{}", cfg.bind, cfg.port);
+    let addr = config::format_bind_address(&cfg.bind, cfg.port);
     info!(vault = %cfg.vault_path.display(), bind = %cfg.bind, port = cfg.port, "Compass starting");
 
     // 初始化 DB
@@ -66,8 +66,12 @@ async fn main() -> anyhow::Result<()> {
     // 启动 HTTP API
     // 接线静态文件 + 根路由
     let web_dir = std::path::Path::new("web");
-    let app = api::router_from_config(Arc::new(cfg), db)
-        .fallback_service(tower_http::services::ServeDir::new(web_dir));
+    let cfg = Arc::new(cfg);
+    let app = api::apply_security(
+        api::router_from_config(Arc::clone(&cfg), db)
+            .fallback_service(tower_http::services::ServeDir::new(web_dir)),
+        &cfg,
+    );
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!(%addr, "listening");
     axum::serve(listener, app).await?;

--- a/compass-core/src/main.rs
+++ b/compass-core/src/main.rs
@@ -28,8 +28,8 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cfg = config::Config::load()?;
-    let addr = format!("0.0.0.0:{}", cfg.port);
-    info!(vault = %cfg.vault_path.display(), port = cfg.port, "Compass starting");
+    let addr = format!("{}:{}", cfg.bind, cfg.port);
+    info!(vault = %cfg.vault_path.display(), bind = %cfg.bind, port = cfg.port, "Compass starting");
 
     // 初始化 DB
     let db_path = cfg


### PR DESCRIPTION
## Summary`n`n- default HTTP bind is 127.0.0.1`n- require explicit allow_non_local = true for non-local binds`n- add optional Bearer token authentication`n- apply auth and request-size protection after the static fallback is composed`n- enforce configurable request body limits (default 1 MiB)`n- format IPv6 binds correctly`n- document the trust boundary and add regression tests`n`nCloses #206`nFixes #209`n`n## Verification`n`n- cargo test --locked (125 passed)`n- cargo fmt --check`n- cargo clippy --all-targets -- -D warnings`n- python -m unittest test_compass.py test_e2e.py (32 passed)