### PR TITLE
fix(phase4): close validation and runtime test gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ Compass/
 
 验收路径：`skill action → Rust HTTP API → vault/frontmatter → FileWatcher → skill render`。
 
-### Phase 4 · 智能增强（准备完成，待实现）
+### Phase 4 · 智能增强 ✅
 
 实施入口：[`docs/PHASE4_PREP.md`](docs/PHASE4_PREP.md)。
 
-Phase 4 只做可解释建议和结构化周报：LLM 由已有 Agent/skill 调用，Compass 不自动覆盖标签/链接、不实现 Feishu ws；Phase 4 的建议写回必须经过显式确认和 content hash 校验，Phase 1-3 的 score/access/create 合同保持不变。
+Phase 4 已完成可解释标签建议、关联推荐、显式 accept/reject、content hash 过期保护和结构化周报。LLM 仍由已有 Agent/skill 调用，Compass 不自动覆盖标签/链接、不实现 Feishu ws；Phase 1-3 的 score/access/create 合同保持不变。
 
 ## 测试
 
@@ -199,9 +199,9 @@ cd compass-core
 cargo test
 ```
 
-119 个 Rust 测试覆盖：评分引擎 / frontmatter 读写 / SQLite 索引 / FTS5 / FileWatcher / API / 端到端闭环。
+149 个 Rust 测试覆盖：评分引擎 / frontmatter 读写 / SQLite 索引 / 中英文搜索 / FileWatcher / API / Phase 4 契约 / 端到端闭环。
 
-skill 侧另有 18 个 renderer 单测和 14 个 HTTP E2E：
+skill 侧另有 21 个 renderer 单测和 17 个 HTTP E2E（含 Phase 4 边界与混合负载回归）：
 
 ```bash
 cd skills/compass

--- a/compass-core/src/api.rs
+++ b/compass-core/src/api.rs
@@ -436,6 +436,11 @@ pub(crate) async fn feed(
     State(state): State<AppState>,
     Query(q): Query<FeedQuery>,
 ) -> Result<Json<Vec<EntitySummary>>, AppError> {
+    if !matches!(q.mode.as_str(), "explore" | "consolidate" | "strategic") {
+        return Err(AppError::unprocessable(
+            "mode must be explore, consolidate, or strategic",
+        ));
+    }
     let db = state.db.lock().await;
     let entities = db.list_entities()?;
     let mut summaries: Vec<EntitySummary> = entities
@@ -466,7 +471,7 @@ pub(crate) async fn feed(
                 (None, None) => std::cmp::Ordering::Equal,
             });
         }
-        _ => {
+        "explore" => {
             summaries.sort_by(|a, b| {
                 b.composite
                     .unwrap_or(0.0)
@@ -474,6 +479,7 @@ pub(crate) async fn feed(
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
         }
+        _ => unreachable!("feed mode validated above"),
     }
     summaries.truncate(q.limit as usize);
     Ok(Json(summaries))
@@ -571,8 +577,13 @@ pub(crate) async fn search(
 pub(crate) async fn tag_suggestions(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<TagSuggestionsRequest>>,
+    Json(request): Json<TagSuggestionsRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    if request.candidates.len() > crate::contracts::MAX_SUGGESTIONS_PER_REQUEST {
+        return Err(AppError::unprocessable(
+            "candidates must contain at most 20 items",
+        ));
+    }
     let db = state.db.lock().await;
     let entity = db
         .get_entity(&id)?
@@ -584,7 +595,7 @@ pub(crate) async fn tag_suggestions(
         .map_err(|e| AppError::internal(&format!("解析笔记失败: {e}")))?;
     let content_hash = note_content_hash(&raw)?;
     let existing = frontmatter::extract_tags(&note.frontmatter);
-    let candidates = match body.map(|json| json.0).unwrap_or_default().candidates {
+    let candidates = match request.candidates {
         candidates if candidates.is_empty() => {
             lexical_tag_candidates(&note.frontmatter, &note.body, &existing, &content_hash)
         }
@@ -1190,6 +1201,9 @@ pub(crate) async fn agent_context(
     State(state): State<AppState>,
     Json(req): Json<AgentContextRequest>,
 ) -> Result<Json<AgentContextResponse>, AppError> {
+    if req.task.trim().is_empty() {
+        return Err(AppError::unprocessable("task must not be empty"));
+    }
     let db = state.db.lock().await;
 
     // 1. FTS5 语义召回（最多 3*top_k，留足排序空间）
@@ -1846,10 +1860,14 @@ mod tests {
         .unwrap();
         drop(db);
 
-        let created = tag_suggestions(State(state.clone()), Path("know-tag".to_string()), None)
-            .await
-            .unwrap()
-            .0;
+        let created = tag_suggestions(
+            State(state.clone()),
+            Path("know-tag".to_string()),
+            Json(TagSuggestionsRequest::default()),
+        )
+        .await
+        .unwrap()
+        .0;
         let suggestions = created["suggestions"].as_array().unwrap();
         assert!(!suggestions.is_empty());
         let accept_id = suggestions[0]["suggestion_id"]
@@ -1900,10 +1918,14 @@ mod tests {
         .unwrap();
         drop(db);
 
-        let created = tag_suggestions(State(state.clone()), Path("know-stale".to_string()), None)
-            .await
-            .unwrap()
-            .0;
+        let created = tag_suggestions(
+            State(state.clone()),
+            Path("know-stale".to_string()),
+            Json(TagSuggestionsRequest::default()),
+        )
+        .await
+        .unwrap()
+        .0;
         let suggestion_id = created["suggestions"][0]["suggestion_id"]
             .as_str()
             .unwrap()
@@ -2466,6 +2488,24 @@ mod tests {
         assert_eq!(r[0].id, "know-high", "explore 按 composite 降序");
         assert_eq!(r[1].id, "know-low");
     }
+
+    #[tokio::test]
+    async fn test_feed_rejects_unknown_mode() {
+        let dir = tempdir().unwrap();
+        let state = setup_state(dir.path());
+        let error = feed(
+            State(state),
+            Query(FeedQuery {
+                mode: "invalid".to_string(),
+                limit: 10,
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, AppError::Unprocessable(_)));
+    }
+
     #[tokio::test]
     async fn test_entities_top_layer_filter() {
         let dir = tempdir().unwrap();

--- a/compass-core/src/db.rs
+++ b/compass-core/src/db.rs
@@ -529,6 +529,9 @@ impl Db {
 
     /// FTS5 搜索。query 按空白拆词、各自加引号后 AND 连接（避免 `-`/`*` 等被当作 FTS 语法）。
     pub fn fts_search(&self, query: &str, limit: u32) -> Result<Vec<FtsHit>> {
+        if contains_cjk(query) {
+            return self.cjk_substring_search(query, limit);
+        }
         let q = fts_query(query);
         if q.is_empty() {
             return Ok(vec![]);
@@ -550,6 +553,59 @@ impl Db {
         })?;
         rows.collect::<rusqlite::Result<Vec<_>>>()
             .map_err(Into::into)
+    }
+
+    fn cjk_substring_search(&self, query: &str, limit: u32) -> Result<Vec<FtsHit>> {
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+        let terms = query
+            .split_whitespace()
+            .filter(|term| !term.is_empty())
+            .map(str::to_lowercase)
+            .collect::<Vec<_>>();
+        if terms.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.title, f.content
+             FROM entities_fts f
+             JOIN entities e ON e.rowid = f.rowid
+             ORDER BY e.composite IS NULL, e.composite DESC, e.id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let mut hits = Vec::new();
+        for row in rows {
+            let (id, title, content) = row?;
+            let title_lowercase = title.as_deref().unwrap_or("").to_lowercase();
+            let content_lowercase = content.to_lowercase();
+            let searchable = format!("{title_lowercase}\n{content_lowercase}");
+            if terms.iter().all(|term| searchable.contains(term)) {
+                let snippet_source = if content_lowercase.contains(&terms[0]) {
+                    content.as_str()
+                } else {
+                    title.as_deref().unwrap_or(content.as_str())
+                };
+                let snippet = search_snippet(snippet_source, &terms[0]);
+                hits.push(FtsHit {
+                    id,
+                    title,
+                    snippet: Some(snippet),
+                });
+                if hits.len() >= limit as usize {
+                    break;
+                }
+            }
+        }
+        Ok(hits)
     }
 
     /// 该实体某触发器类型最近一次触发时间（供 T1.3 冷却判断）。
@@ -897,6 +953,41 @@ fn fts_query(q: &str) -> String {
         .filter(|w| w != "\"\"")
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn contains_cjk(value: &str) -> bool {
+    value.chars().any(|character| {
+        matches!(
+            character as u32,
+            0x3400..=0x4DBF
+                | 0x4E00..=0x9FFF
+                | 0xF900..=0xFAFF
+                | 0x3040..=0x30FF
+                | 0xAC00..=0xD7AF
+        )
+    })
+}
+
+fn search_snippet(content: &str, term: &str) -> String {
+    const CONTEXT_BEFORE: usize = 40;
+    const MAX_CHARS: usize = 160;
+
+    let lowercase = content.to_lowercase();
+    let match_byte = lowercase.find(term).unwrap_or(0);
+    let match_char = lowercase[..match_byte].chars().count();
+    let start = match_char.saturating_sub(CONTEXT_BEFORE);
+    let snippet = content
+        .chars()
+        .skip(start)
+        .take(MAX_CHARS)
+        .collect::<String>();
+    let prefix = if start > 0 { "..." } else { "" };
+    let suffix = if content.chars().count() > start + MAX_CHARS {
+        "..."
+    } else {
+        ""
+    };
+    format!("{prefix}{snippet}{suffix}")
 }
 
 /// 递归遍历 .md 文件，跳过隐藏目录/文件（.obsidian/.compass/.git 等）。
@@ -1254,6 +1345,47 @@ mod tests {
         let hits = db.fts_search("Nash equilibrium", 10).unwrap();
         assert_eq!(hits.len(), 1, "多词应 AND，只命中含两词的");
         assert_eq!(hits[0].id, "know-1");
+    }
+
+    #[test]
+    fn test_fts_search_cjk_substring() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(
+            &sample_row("know-cn"),
+            "Compass 使用三维评分引擎管理个人知识。",
+        )
+        .unwrap();
+
+        let hits = db.fts_search("评分", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "know-cn");
+        assert!(hits[0].snippet.as_deref().unwrap().contains("评分"));
+    }
+
+    #[test]
+    fn test_fts_search_cjk_terms_use_and_semantics() {
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("know-both"), "评分引擎用于知识管理")
+            .unwrap();
+        db.upsert_entity(&sample_row("know-one"), "只有评分内容")
+            .unwrap();
+
+        let hits = db.fts_search("评分 知识", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "know-both");
+    }
+
+    #[test]
+    fn test_fts_search_cjk_title_hit_and_zero_limit() {
+        let db = Db::open_in_memory().unwrap();
+        let mut row = sample_row("know-title");
+        row.title = Some("认知科学索引".to_string());
+        db.upsert_entity(&row, "unrelated body").unwrap();
+
+        let hits = db.fts_search("认知", 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].snippet.as_deref().unwrap().contains("认知"));
+        assert!(db.fts_search("认知", 0).unwrap().is_empty());
     }
 
     #[test]

--- a/docs/PHASE1_4_TEST_REPORT.md
+++ b/docs/PHASE1_4_TEST_REPORT.md
@@ -1,0 +1,114 @@
+# Compass Phase 1-4 测试报告
+
+> 日期：2026-07-11
+> 范围：Phase 1-4 最终收尾
+> 环境：Windows 10 / Rust release / Python unittest
+> 原则：所有写入型黑盒测试均使用临时 Vault，不修改真实 Vault
+
+---
+
+## 0. 结论
+
+Phase 1-4 验收通过，可以进入 Phase 5。
+
+| 验收层 | 结果 |
+|---|---|
+| Rust 单元与模块 E2E | 149 passed / 0 failed / 0 ignored |
+| Skill HTTP E2E | 17 passed / 0 failed |
+| Skill renderer | 21 passed / 0 failed |
+| Phase 4 HTTP 边界 | 通过 |
+| 混合 TCP 负载 | 通过，服务最终健康检查为 200 |
+| 真实 Vault 副作用 | 已清理 |
+
+## 1. 最终修复
+
+### 1.1 运行时稳定性
+
+初版报告把一次临时批量探测中的服务失活直接定性为 axum 死锁，但未保存可复跑脚本、退出码、线程栈或完整连接生命周期，因此不足以证明服务端死锁。
+
+收尾处理：
+
+- 将混合 TCP 负载固化到 `skills/compass/test_e2e.py`。
+- 每个成功响应使用上下文管理器关闭。
+- 每个 `HTTPError` 在读取响应体后显式 `close()`。
+- 使用临时 Vault 和独立端口，不与真实服务或真实数据混用。
+- 覆盖 health、中文 search、feed、agent context、422 错误响应和 access 写回，累计超过原报告的 20-40 请求阈值。
+- 压测结束后断言服务进程仍存活，并再次检查 `GET /health == 200`。
+
+结果：回归通过；测试期间观察到正常 `TIME_WAIT`，未观察到原报告所称的 `CLOSE_WAIT` 堆积。现有证据不支持“已确认服务端死锁”的结论。
+
+### 1.2 Feed 非法模式
+
+`GET /feed?mode=invalid` 现在返回 422，不再静默回退到 explore。合法值仅为：
+
+- `explore`
+- `consolidate`
+- `strategic`
+
+### 1.3 中文搜索
+
+英文查询继续使用 FTS5 MATCH 和 rank。包含 CJK 字符的查询使用参数化索引内容子串兜底：
+
+- 支持两字中文查询，例如“评分”。
+- 多个空白分隔词保持 AND 语义。
+- snippet 限制长度，避免返回整篇正文。
+- 不修改 FTS schema，因此无需迁移或重建数据库。
+
+说明：FTS5 默认 tokenizer 已是 `unicode61`，仅显式改成 `unicode61` 不能解决中文分词问题。
+
+### 1.4 Phase 4 请求契约
+
+补齐并验证：
+
+- Agent context 空 task / 缺 task：422。
+- Tag agent candidate 缺必填字段：422。
+- Tag candidates 超过 20 项：422。
+- 不存在的实体或 suggestion：404。
+- accept 重复调用：幂等。
+- reject 已 accepted suggestion：409。
+- Related 返回 reasons，并排除自身。
+- Weekly 缺时区、非法时区、非法日期、反向区间：422。
+- Weekly 同参数调用结果确定。
+
+同时修复了一个实际缺陷：原 `Option<Json<TagSuggestionsRequest>>` 会把非法 agent candidate 的反序列化失败吞掉并回退到 lexical 候选；现在请求体必须通过 JSON schema。
+
+## 2. Phase 验收地图
+
+| Phase | 验收内容 | 状态 |
+|---|---|---|
+| 1 | frontmatter、评分、SQLite、FileWatcher、基础 API | 通过 |
+| 2 | 衰减、Feed 三模式、Graph | 通过 |
+| 3 | skill action、HTTP API、render | 通过 |
+| 4 | tags、related、accept/reject、weekly、content hash | 通过 |
+
+当前 router 注册 18 条实际 HTTP 路径。此前“14 个端点”的统计把多组 accept/reject 路径合并计算，已不作为验收口径。
+
+## 3. 测试命令
+
+```powershell
+cargo test --release --manifest-path compass-core/Cargo.toml
+python -m unittest -q skills/compass/test_compass.py
+python -m unittest -q skills/compass/test_e2e.py
+cargo fmt --manifest-path compass-core/Cargo.toml -- --check
+cargo clippy --manifest-path compass-core/Cargo.toml --all-targets -- -D warnings
+git diff --check
+```
+
+## 4. 数据清理
+
+初版黑盒探测写入真实 Vault 的以下测试文件已确认并删除：
+
+- `vault/Knowledge/know000004.md`
+- `vault/Knowledge/know000005.md`
+- `vault/Knowledge/know000007.md`
+- `vault/Insights/ins000001.md`
+
+`know000006.md` 在清理时不存在。后续 E2E 使用临时目录，并在 teardown 中自动删除。
+
+## 5. 剩余风险
+
+- CJK 子串兜底为线性扫描索引内容，适合个人 Vault；若数据量显著增长，再评估 trigram 或中文 tokenizer。
+- 当前稳定性回归覆盖短时混合负载，不替代数小时 soak test。
+- SQLite 仍由单一 mutex 串行访问；当前回归未发现死锁，但高并发吞吐不是本阶段目标。
+
+这些风险不阻塞 Phase 4 收尾。

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -13,7 +13,7 @@
 | 1 | 核心闭环 | 2-3 周 | ✅ 完成 | Obsidian 新建笔记→引擎算分写回 frontmatter→Dataview 排序可见 |
 | 2 | 浮现与可视化 | 2 周 | ✅ 完成 | `/feed` 浮现正确；Web 引力场节点大小=评分 |
 | 3 | Agent/Skill 对接 | 1-2 周 | ✅ 完成 | skill action→Compass API→vault；本地 E2E 覆盖 action + render + FileWatcher |
-| 4 | 智能增强 | 按需 | 准备完成 | 可解释标签建议/关联推荐/周报 |
+| 4 | 智能增强 | 按需 | ✅ 完成 | 可解释标签建议/关联推荐/周报 |
 | 5 | 打磨 | 按需 | 待开发 | Dataview 模板库 + Git 备份 + 跨端同步 |
 
 **总周期：5-8 周。**
@@ -78,7 +78,7 @@
 
 ---
 
-## 4. Phase 4 · 智能增强（T4.0-T4.5 已完成）
+## 4. Phase 4 · 智能增强（T4.0-T4.7 已完成）
 
 Phase 4 的实施入口是 [`docs/PHASE4_PREP.md`](PHASE4_PREP.md)。先冻结协议和责任边界，再进入运行时开发：
 
@@ -111,6 +111,6 @@ Phase 1、Phase 2、Phase 3 已完成。Phase 3 的本地验收从 `skills/compa
 
 `skill action → Rust HTTP API → frontmatter/SQLite → FileWatcher → skill render`
 
-证据：`skills/compass/test_e2e.py`（15 个 E2E）和 `skills/compass/test_compass.py`（21 个 renderer 单测）。
+证据：`cargo test --release`（149 个 Rust 测试）、`skills/compass/test_e2e.py`（17 个 HTTP/skill E2E）和 `skills/compass/test_compass.py`（21 个 renderer 单测）。完整验收见 [`docs/PHASE1_4_TEST_REPORT.md`](PHASE1_4_TEST_REPORT.md)。
 
 Phase 4 已完成 T4.0-T4.7。skill 已覆盖标签候选、关联推荐、accept/reject 与周报，并通过 action → Rust API → Vault/SQLite → render 的本地 E2E。

--- a/skills/compass/test_e2e.py
+++ b/skills/compass/test_e2e.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import unittest
 import urllib.error
+import urllib.parse
 import urllib.request
 
 COMPASS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -62,6 +63,34 @@ def compass_render_stdin(raw, action, env):
         env=env,
     )
     return result.stdout, result.stderr, result.returncode
+
+
+def http_json(base_url, path, method="GET", payload=None, timeout=5):
+    def decode(body):
+        if not body:
+            return None
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return body
+
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}{path}", data=data, method=method
+    )
+    request.add_header("Accept", "application/json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return response.status, decode(body)
+    except urllib.error.HTTPError as error:
+        try:
+            body = error.read().decode("utf-8")
+            return error.code, decode(body)
+        finally:
+            error.close()
 
 
 class TestE2ESkillAgainstApi(unittest.TestCase):
@@ -356,6 +385,16 @@ class TestE2ESkillAgainstApi(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertIn("建议已接受", rendered)
+        raw, err, rc = compass_cli(
+            "accept_tag", f"suggestion_id={accepted_id}", env=self.env
+        )
+        self.assertEqual(rc, 0, f"repeated tag accept failed: {err}")
+        self.assertEqual(json.loads(raw)["status"], "accepted")
+        _, err, rc = compass_cli(
+            "reject_tag", f"suggestion_id={accepted_id}", env=self.env
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("409", err)
         with open(tag_source_path, encoding="utf-8") as f:
             updated_note = f.read()
         self.assertIn("tags:", updated_note)
@@ -403,6 +442,16 @@ class TestE2ESkillAgainstApi(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
         self.assertIn("建议已接受", rendered)
+        raw, err, rc = compass_cli(
+            "accept_related", f"suggestion_id={target['suggestion_id']}", env=self.env
+        )
+        self.assertEqual(rc, 0, f"repeated related accept failed: {err}")
+        self.assertEqual(json.loads(raw)["status"], "accepted")
+        _, err, rc = compass_cli(
+            "reject_related", f"suggestion_id={target['suggestion_id']}", env=self.env
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("409", err)
         with open(source_path, encoding="utf-8") as f:
             self.assertIn("[[know-000001]]", f.read())
 
@@ -421,6 +470,152 @@ class TestE2ESkillAgainstApi(unittest.TestCase):
         )
         self.assertEqual(rc, 0, f"weekly render failed: {err}")
         self.assertIn("周报", rendered)
+
+    def test_phase4_http_contract_boundaries(self):
+        base_url = self.env["COMPASS_API_URL"]
+
+        status, _ = http_json(base_url, "/feed?mode=invalid")
+        self.assertEqual(status, 422)
+        status, _ = http_json(
+            base_url, "/agent/context", method="POST", payload={"task": ""}
+        )
+        self.assertEqual(status, 422)
+        status, _ = http_json(
+            base_url, "/agent/context", method="POST", payload={}
+        )
+        self.assertEqual(status, 422)
+
+        status, _ = http_json(
+            base_url,
+            "/entities/missing/tag-suggestions",
+            method="POST",
+            payload={},
+        )
+        self.assertEqual(status, 404)
+        status, _ = http_json(
+            base_url,
+            "/tag-suggestions/missing/accept",
+            method="POST",
+        )
+        self.assertEqual(status, 404)
+
+        status, lexical = http_json(
+            base_url,
+            "/entities/know-000001/tag-suggestions",
+            method="POST",
+            payload={},
+        )
+        self.assertEqual(status, 200)
+        candidate = {
+            "tag": "decision-science",
+            "confidence": 0.8,
+            "reason": "agent candidate",
+            "source": "agent",
+            "content_hash": lexical["content_hash"],
+        }
+        status, _ = http_json(
+            base_url,
+            "/entities/know-000001/tag-suggestions",
+            method="POST",
+            payload={"candidates": [candidate]},
+        )
+        self.assertEqual(status, 422)
+        candidate["algorithm_version"] = "agent-v1"
+        candidates = [
+            {**candidate, "tag": f"candidate-{index}"}
+            for index in range(21)
+        ]
+        status, _ = http_json(
+            base_url,
+            "/entities/know-000001/tag-suggestions",
+            method="POST",
+            payload={"candidates": candidates},
+        )
+        self.assertEqual(status, 422)
+
+        status, related = http_json(
+            base_url, "/entities/know-000001/related?limit=5"
+        )
+        self.assertEqual(status, 200)
+        self.assertTrue(related["suggestions"])
+        self.assertTrue(related["suggestions"][0]["reasons"])
+        self.assertNotIn(
+            "know-000001",
+            {item["id"] for item in related["suggestions"]},
+        )
+        status, _ = http_json(base_url, "/entities/missing/related")
+        self.assertEqual(status, 404)
+
+        valid_weekly = (
+            "/reports/weekly?from=2026-07-01&to=2026-07-12"
+            "&tz=Asia%2FShanghai"
+        )
+        status, first = http_json(base_url, valid_weekly)
+        self.assertEqual(status, 200)
+        status, second = http_json(base_url, valid_weekly)
+        self.assertEqual(status, 200)
+        self.assertEqual(first, second)
+        for query in (
+            "from=2026-07-01&to=2026-07-12",
+            "from=2026-07-01&to=2026-07-12&tz=Bogus%2FZone",
+            "from=notdate&to=2026-07-12&tz=Asia%2FShanghai",
+            "from=2026-07-12&to=2026-07-01&tz=Asia%2FShanghai",
+        ):
+            status, _ = http_json(base_url, f"/reports/weekly?{query}")
+            self.assertEqual(status, 422)
+
+    def test_runtime_stability_under_mixed_http_load(self):
+        raw, err, rc = compass_cli(
+            "create",
+            "title=Runtime Stability",
+            "layer=knowledge",
+            "content=中文评分引擎 mixed load regression",
+            env=self.env,
+        )
+        self.assertEqual(rc, 0, f"create failed: {err}")
+        entity = json.loads(raw)
+        self.created_files.append(os.path.join(self.vault, entity["file_path"]))
+        base_url = self.env["COMPASS_API_URL"]
+
+        # More than 40 mixed TCP requests, including successful writes and
+        # intentionally rejected requests, exceed the original failure report
+        # while keeping the regular E2E suite practical on Windows.
+        for iteration in range(10):
+            status, health = http_json(base_url, "/health")
+            self.assertEqual((status, health["status"]), (200, "ok"))
+
+            status, results = http_json(
+                base_url,
+                "/search?q=" + urllib.parse.quote("评分"),
+            )
+            self.assertEqual(status, 200)
+            self.assertTrue(any(item["id"] == entity["id"] for item in results))
+
+            status, _ = http_json(base_url, "/feed?mode=explore&limit=5")
+            self.assertEqual(status, 200)
+
+            status, _ = http_json(
+                base_url,
+                "/agent/context",
+                method="POST",
+                payload={"task": "mixed load", "top_k": 3},
+            )
+            self.assertEqual(status, 200)
+
+            if iteration % 5 == 0:
+                status, _ = http_json(base_url, "/feed?mode=invalid")
+                self.assertEqual(status, 422)
+                status, _ = http_json(
+                    base_url,
+                    f"/entities/{entity['id']}/access",
+                    method="PATCH",
+                    payload={"depth": "read"},
+                )
+                self.assertEqual(status, 200)
+
+        self.assertIsNone(self.server_proc.poll(), "Compass exited during mixed load")
+        status, health = http_json(base_url, "/health")
+        self.assertEqual((status, health["status"]), (200, "ok"))
 
     def test_create_and_score_and_access(self):
         # create


### PR DESCRIPTION
## Summary
- enforce feed, agent context, and tag-candidate request boundaries
- add CJK search fallback without a schema migration
- add isolated Phase 4 HTTP contract and mixed-load regressions
- replace the initial test report with reproducible final evidence and clean stale status docs

## Verification
- cargo test --release: 149 passed
- python -m unittest -q skills/compass/test_e2e.py: 17 passed
- python -m unittest -q skills/compass/test_compass.py: 21 passed
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- git diff --check