### PR TITLE
fix(index): exclude unrendered Templater templates

### DIFF
--- a/compass-core/src/db.rs
+++ b/compass-core/src/db.rs
@@ -1007,6 +1007,9 @@ fn walk_md_inner(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
             continue;
         }
         if path.is_dir() {
+            if name == "Templates" {
+                continue;
+            }
             walk_md_inner(&path, out)?;
         } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
             out.push(path);
@@ -1025,6 +1028,9 @@ struct ParsedEntity {
 
 fn parse_entity(vault: &Path, path: &Path) -> Result<Option<ParsedEntity>> {
     let note = frontmatter::read_note(path)?;
+    if frontmatter::has_unrendered_templater_marker(&note.frontmatter) {
+        return Ok(None);
+    }
     let fm: serde_yaml::Value =
         serde_yaml::from_str(&note.frontmatter).context("解析 frontmatter 失败")?;
     let m = fm
@@ -1655,6 +1661,73 @@ mod tests {
         assert!(db.get_entity("hidden-1").unwrap().is_none());
         assert!(db.fts_search("hidden", 10).unwrap().is_empty());
         assert!(db.fts_search("visible", 10).unwrap().len() == 1);
+    }
+
+    #[test]
+    fn test_rebuild_skips_templates_at_any_depth() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        fs::create_dir_all(vault.join("Templates")).unwrap();
+        fs::create_dir_all(vault.join("Knowledge").join("Templates")).unwrap();
+        fs::write(
+            vault.join("Templates").join("knowledge.md"),
+            md_with_id("template-root", "Root template", "template root body"),
+        )
+        .unwrap();
+        fs::write(
+            vault.join("Knowledge").join("Templates").join("case.md"),
+            md_with_id("template-nested", "Nested template", "template nested body"),
+        )
+        .unwrap();
+        fs::create_dir_all(vault.join("Knowledge").join("Math")).unwrap();
+        fs::write(
+            vault.join("Knowledge").join("Math").join("know-1.md"),
+            md_with_id("know-1", "Indexed", "normal recursive body"),
+        )
+        .unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert_eq!(stats.indexed, 1);
+        assert!(db.get_entity("template-root").unwrap().is_none());
+        assert!(db.get_entity("template-nested").unwrap().is_none());
+        assert!(db.fts_search("template", 10).unwrap().is_empty());
+        assert!(db.get_entity("know-1").unwrap().is_some());
+    }
+
+    #[test]
+    fn test_rebuild_skips_unrendered_templater_frontmatter_and_cleans_dirty_index() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(
+            vault.join("unrendered.md"),
+            md_with_id(
+                "case-<% tp.date.now(\"YYMMDD\") %>",
+                "<% tp.file.title %>",
+                "template source body",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            vault.join("know-1.md"),
+            md_with_id("know-1", "Indexed", "normal body"),
+        )
+        .unwrap();
+
+        let db = Db::open_in_memory().unwrap();
+        db.upsert_entity(&sample_row("dirty-template"), "stale template entry")
+            .unwrap();
+        let stats = db.rebuild_from_vault(&vault).unwrap();
+        assert_eq!(stats.indexed, 1);
+        assert_eq!(stats.skipped, 1);
+        assert!(db.get_entity("dirty-template").unwrap().is_none());
+        assert!(db
+            .get_entity("case-<% tp.date.now(\"YYMMDD\") %>")
+            .unwrap()
+            .is_none());
+        assert!(db.fts_search("template", 10).unwrap().is_empty());
+        assert!(db.get_entity("know-1").unwrap().is_some());
     }
 
     #[test]

--- a/compass-core/src/frontmatter.rs
+++ b/compass-core/src/frontmatter.rs
@@ -65,6 +65,12 @@ pub fn read_note(path: &Path) -> Result<Note> {
     Ok(Note { frontmatter, body })
 }
 
+/// Returns true when frontmatter still contains a Templater expression.
+/// These notes are source templates rather than indexable entities.
+pub fn has_unrendered_templater_marker(frontmatter: &str) -> bool {
+    frontmatter.contains("<%") || frontmatter.contains("%>")
+}
+
 /// Apply the selected metadata changes under the same advisory lock used by score writes.
 /// The expected hash is computed from the raw authoritative Markdown note, excluding only
 /// the top-level score block as defined by `sha256-note-v1`.

--- a/compass-core/src/watcher.rs
+++ b/compass-core/src/watcher.rs
@@ -34,6 +34,7 @@ const DEFAULT_CONSENSUS: f64 = 5.0;
 
 /// 隐藏目录列表（跳过这些目录下的事件）
 const HIDDEN_DIRS: &[&str] = &[".obsidian", ".compass", ".git"];
+const TEMPLATE_DIR: &str = "Templates";
 
 /// FileWatcher 配置
 pub struct FileWatcher {
@@ -161,8 +162,24 @@ pub(crate) async fn process_single_file(
         return Ok(());
     }
 
+    if is_template_path(vault, path) {
+        let relative = rel_path(vault, path);
+        let db = db.lock().await;
+        db.delete_entities_under_path(&relative)?;
+        return Ok(());
+    }
+
     // 读取 frontmatter
     let note = frontmatter::read_note(path)?;
+
+    if frontmatter::has_unrendered_templater_marker(&note.frontmatter) {
+        let relative = rel_path(vault, path);
+        let db = db.lock().await;
+        if let Some(existing_id) = db.entity_id_by_file_path(&relative)? {
+            db.delete_entity(&existing_id)?;
+        }
+        return Ok(());
+    }
 
     // 解析 id（无 id 跳过）
     let id = match extract_id_from_frontmatter(&note.frontmatter) {
@@ -462,6 +479,14 @@ fn is_hidden_path(paths: &[PathBuf]) -> bool {
     false
 }
 
+fn is_template_path(vault: &Path, path: &Path) -> bool {
+    path.strip_prefix(vault)
+        .ok()
+        .into_iter()
+        .flat_map(|relative| relative.components())
+        .any(|component| component.as_os_str() == TEMPLATE_DIR)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -535,6 +560,84 @@ mod tests {
         let entity = db.lock().await.get_entity("know-000001").unwrap().unwrap();
         assert_eq!(entity.title.as_deref(), Some("Test"));
         assert!((entity.composite.unwrap() - 85.5).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn test_process_single_file_removes_template_and_unrendered_entries() {
+        let dir = tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        let templates = vault.join("Knowledge").join("Templates");
+        fs::create_dir_all(&templates).unwrap();
+        let template_path = templates.join("case.md");
+        fs::write(
+            &template_path,
+            "---\nid: case-template\ntitle: Template\n---\ntemplate body\n",
+        )
+        .unwrap();
+        let unrendered_path = vault.join("unrendered.md");
+        fs::write(
+            &unrendered_path,
+            "---\nid: case-<% tp.date.now(\"YYMMDD\") %>\ntitle: Template\n---\ntemplate body\n",
+        )
+        .unwrap();
+
+        let db = Arc::new(Mutex::new(Db::open_in_memory().unwrap()));
+        let weights = Weights::default();
+        {
+            let db_guard = db.lock().await;
+            db_guard
+                .upsert_entity(
+                    &EntityRow {
+                        id: "case-template".to_string(),
+                        file_path: "Knowledge/Templates/case.md".to_string(),
+                        title: Some("Template".to_string()),
+                        layer: None,
+                        status: None,
+                        interest: None,
+                        strategy: None,
+                        consensus: None,
+                        composite: None,
+                        access_count: 0,
+                        last_boosted_at: None,
+                        content_hash: None,
+                        updated_at: None,
+                    },
+                    "template body",
+                )
+                .unwrap();
+            db_guard
+                .upsert_entity(
+                    &EntityRow {
+                        id: "case-unrendered".to_string(),
+                        file_path: "unrendered.md".to_string(),
+                        title: Some("Template".to_string()),
+                        layer: None,
+                        status: None,
+                        interest: None,
+                        strategy: None,
+                        consensus: None,
+                        composite: None,
+                        access_count: 0,
+                        last_boosted_at: None,
+                        content_hash: None,
+                        updated_at: None,
+                    },
+                    "template body",
+                )
+                .unwrap();
+        }
+
+        process_single_file(&vault, &db, &weights, &template_path)
+            .await
+            .unwrap();
+        process_single_file(&vault, &db, &weights, &unrendered_path)
+            .await
+            .unwrap();
+
+        let db_guard = db.lock().await;
+        assert!(db_guard.get_entity("case-template").unwrap().is_none());
+        assert!(db_guard.get_entity("case-unrendered").unwrap().is_none());
+        assert!(db_guard.fts_search("template", 10).unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #230\n\n- skip Templates directories during recursive Vault rebuilds\n- reject frontmatter containing unrendered Templater markers\n- prevent the watcher from restoring template entries and clean legacy rows\n- add rebuild and watcher regression coverage